### PR TITLE
M1475: Clean up the duplicate sample unit on submitted record save

### DIFF
--- a/src/api/resources/sample_units/__init__.py
+++ b/src/api/resources/sample_units/__init__.py
@@ -13,6 +13,7 @@ from ...report_serializer import *
 from ...reports import csv_report
 from ...resources.base import BaseApiViewSet, BaseProjectApiViewSet
 from ...utils import truthy
+from ...utils.sample_units import consolidate_sample_events, has_duplicate_sample_events
 
 
 def save_one_to_many(foreign_key, database_records, data, serializer_class, context):
@@ -71,6 +72,18 @@ def save_model(data, serializer_class, context):
 
     serializer.save()
     return True, None
+
+
+def clean_sample_event_models(data):
+    site = data.get("site")
+    management = data.get("management")
+    sample_date = data.get("sample_date")
+    if has_duplicate_sample_events(site, management, sample_date):
+        consolidate_sample_events(sample_event_data=dict(
+            site=site,
+            management=management,
+            sample_date=sample_date
+        ))
 
 
 class BaseGeoJsonPagination(GeoJsonPagination):

--- a/src/api/resources/sample_units/beltfishmethod.py
+++ b/src/api/resources/sample_units/beltfishmethod.py
@@ -34,7 +34,12 @@ from ..fish_belt_transect import FishBeltTransectSerializer
 from ..obs_belt_fish import ObsBeltFishSerializer
 from ..observer import ObserverSerializer
 from ..sample_event import SampleEventSerializer
-from . import BaseProjectMethodView, save_model, save_one_to_many
+from . import (
+    BaseProjectMethodView,
+    clean_sample_event_models,
+    save_model,
+    save_one_to_many
+)
 
 
 class ObsBeltFishCSVSerializer(ReportSerializer):
@@ -214,6 +219,8 @@ class BeltFishMethodView(BaseProjectApiViewSet):
             if is_valid is False:
                 transaction.savepoint_rollback(sid)
                 return Response(data=errors, status=status.HTTP_400_BAD_REQUEST)
+
+            clean_sample_event_models(nested_data["sample_event"])
 
             transaction.savepoint_commit(sid)
 

--- a/src/api/resources/sample_units/benthiclitmethod.py
+++ b/src/api/resources/sample_units/benthiclitmethod.py
@@ -35,7 +35,12 @@ from ..benthic_transect import BenthicTransectSerializer
 from ..obs_benthic_lit import ObsBenthicLITSerializer
 from ..observer import ObserverSerializer
 from ..sample_event import SampleEventSerializer
-from . import BaseProjectMethodView, save_model, save_one_to_many
+from . import (
+    BaseProjectMethodView,
+    clean_sample_event_models,
+    save_model,
+    save_one_to_many,
+)
 
 
 class BenthicLITMethodSerializer(BenthicLITSerializer):
@@ -137,6 +142,8 @@ class BenthicLITMethodView(BaseProjectApiViewSet):
             if is_valid is False:
                 transaction.savepoint_rollback(sid)
                 return Response(data=errors, status=status.HTTP_400_BAD_REQUEST)
+
+            clean_sample_event_models(nested_data["sample_event"])
 
             transaction.savepoint_commit(sid)
 

--- a/src/api/resources/sample_units/benthicpitmethod.py
+++ b/src/api/resources/sample_units/benthicpitmethod.py
@@ -34,7 +34,12 @@ from ..benthic_transect import BenthicTransectSerializer
 from ..obs_benthic_pit import ObsBenthicPITSerializer
 from ..observer import ObserverSerializer
 from ..sample_event import SampleEventSerializer
-from . import BaseProjectMethodView, save_model, save_one_to_many
+from . import (
+    BaseProjectMethodView,
+    clean_sample_event_models,
+    save_model,
+    save_one_to_many,
+)
 
 
 class BenthicPITMethodSerializer(BenthicPITSerializer):
@@ -136,6 +141,8 @@ class BenthicPITMethodView(BaseProjectApiViewSet):
             if is_valid is False:
                 transaction.savepoint_rollback(sid)
                 return Response(data=errors, status=status.HTTP_400_BAD_REQUEST)
+
+            clean_sample_event_models(nested_data["sample_event"])
 
             transaction.savepoint_commit(sid)
 

--- a/src/api/resources/sample_units/bleachingquadratcollectionmethod.py
+++ b/src/api/resources/sample_units/bleachingquadratcollectionmethod.py
@@ -40,7 +40,12 @@ from ..obs_quadrat_benthic_percent import ObsQuadratBenthicPercentSerializer
 from ..observer import ObserverSerializer
 from ..quadrat_collection import QuadratCollectionSerializer
 from ..sample_event import SampleEventSerializer
-from . import BaseProjectMethodView, save_model, save_one_to_many
+from . import (
+    BaseProjectMethodView,
+    clean_sample_event_models,
+    save_model,
+    save_one_to_many,
+)
 
 
 class BleachingQuadratCollectionMethodSerializer(BleachingQuadratCollectionSerializer):
@@ -158,6 +163,8 @@ class BleachingQuadratCollectionMethodView(BaseProjectApiViewSet):
             if is_valid is False:
                 transaction.savepoint_rollback(sid)
                 return Response(data=errors, status=status.HTTP_400_BAD_REQUEST)
+
+            clean_sample_event_models(nested_data["sample_event"])
 
             transaction.savepoint_commit(sid)
             bleaching_qc = BleachingQuadratCollection.objects.get(id=bleaching_qc_id)

--- a/src/api/resources/sample_units/habitatcomplexitymethod.py
+++ b/src/api/resources/sample_units/habitatcomplexitymethod.py
@@ -38,7 +38,12 @@ from ..habitat_complexity import HabitatComplexitySerializer
 from ..obs_habitat_complexity import ObsHabitatComplexitySerializer
 from ..observer import ObserverSerializer
 from ..sample_event import SampleEventSerializer
-from . import BaseProjectMethodView, save_model, save_one_to_many
+from . import (
+    BaseProjectMethodView,
+    clean_sample_event_models,
+    save_model,
+    save_one_to_many,
+)
 
 
 class HabitatComplexityMethodSerializer(HabitatComplexitySerializer):
@@ -210,6 +215,8 @@ class HabitatComplexityMethodView(BaseProjectApiViewSet):
             if is_valid is False:
                 transaction.savepoint_rollback(sid)
                 return Response(data=errors, status=status.HTTP_400_BAD_REQUEST)
+
+            clean_sample_event_models(nested_data["sample_event"])
 
             transaction.savepoint_commit(sid)
 

--- a/src/api/utils/sample_units.py
+++ b/src/api/utils/sample_units.py
@@ -121,9 +121,7 @@ def has_duplicate_sample_events(site, management, sample_date):
         "sample_date"
     )
 
-    qry = qry.annotate(num_sample_events=Count("site"))
-    qry = qry.filter(num_sample_events__gt=1)
-    return qry.count() > 0 and qry[0]["num_sample_events"] > 1
+    return qry.count() > 0
 
 
 def consolidate_sample_events(*args, dryrun=False, **kwargs):

--- a/src/api/utils/sample_units.py
+++ b/src/api/utils/sample_units.py
@@ -121,7 +121,7 @@ def has_duplicate_sample_events(site, management, sample_date):
         "sample_date"
     )
 
-    return qry.count() > 0
+    return qry.count() > 1
 
 
 def consolidate_sample_events(*args, dryrun=False, **kwargs):


### PR DESCRIPTION
- Add a method to check after a submitted sample unit method has been updated to check for sample events that are the same and combine them