### PR TITLE
[M1553] Validate the regex before making filtering

### DIFF
--- a/src/api/resources/sample_units/sample_unit_methods.py
+++ b/src/api/resources/sample_units/sample_unit_methods.py
@@ -168,7 +168,6 @@ class SampleUnitMethodView(BaseProjectApiViewSet):
     )
 
     def get_queryset(self):
-        print(self.request.query_params)
         qs = self.queryset
 
         protocol_condition = Case(

--- a/src/api/resources/sample_units/sample_unit_methods.py
+++ b/src/api/resources/sample_units/sample_unit_methods.py
@@ -43,6 +43,11 @@ class SearchNonFieldFilter(django_filters.Filter):
     def filter(self, qs, value):
         value = value or ""
 
+        try:
+            re.compile(value)
+        except re.error:
+            raise exceptions.ValidationError("Invalid search")
+
         qry = Q()
         for field in self.SEARCH_FIELDS:
             qry |= Q(**{"{}__iregex".format(field): value})
@@ -163,6 +168,7 @@ class SampleUnitMethodView(BaseProjectApiViewSet):
     )
 
     def get_queryset(self):
+        print(self.request.query_params)
         qs = self.queryset
 
         protocol_condition = Case(


### PR DESCRIPTION
Checks the search regex string to see if it compiles before filtering sample unit methods and if fails raises a validation error rather than a 500 error