### PR TITLE
Hotfix/improve sqs logging

### DIFF
--- a/src/simpleq/jobs.py
+++ b/src/simpleq/jobs.py
@@ -103,7 +103,7 @@ class Job:
             self.run_time = (self.stop_time - self.start_time).total_seconds()
             self.log(
                 f"Finished job {self.callable.__name__} at {self.stop_time.isoformat()} "
-                "in {self.run_time} seconds."
+                f"in {self.run_time} seconds."
             )
         else:
             self.log(f"Job {self.callable.__name__} failed to run: {self.exception}")

--- a/src/simpleq/jobs.py
+++ b/src/simpleq/jobs.py
@@ -89,9 +89,12 @@ class Job:
     def run(self):
         """Run this job."""
         self.start_time = datetime.utcnow()
-        self.log(
-            f"Starting job {self.callable.__name__} with args [{self.kwargs}] at {self.start_time.isoformat()}"
-        )
+        msg = f"Starting job {self.callable.__name__} at {self.start_time.isoformat()}"
+
+        if self.callable.__name__ == "update_project_summaries":
+            msg = f"Starting job {self.callable.__name__} with args [{self.kwargs}] at {self.start_time.isoformat()}"
+        
+        self.log(msg)
 
         try:
             self.result = self.callable(*self.args, **self.kwargs)

--- a/src/simpleq/jobs.py
+++ b/src/simpleq/jobs.py
@@ -90,7 +90,7 @@ class Job:
         """Run this job."""
         self.start_time = datetime.utcnow()
         self.log(
-            f"Starting job {self.callable.__name__} at {self.start_time.isoformat()}."
+            f"Starting job {self.callable.__name__} with args [{self.kwargs}] at {self.start_time.isoformat()}"
         )
 
         try:


### PR DESCRIPTION
I tested this locally, and I'm getting the general args passed to the callable.

```
simpleq: Starting job _mermaid_email with args [{'subject': 'Changes to Alain Test 2', 'template': 'emails/admins_project_change.html', 'to': ['alain@sparkgeo.com', 'alain@alainstpierre.com'], 'context': {'project_name': 'Alain Test 2', 'profile': <Profile: Alain St. Pierre [5ee0ec8a-2411-4460-ba96-56fbfe7522ca]>, 'collect_project_url': 'https://localhost:8888/#/projects/a53f6169-a278-4caf-ba03-8e7e38838d52/details', 'text_changes': ['Old notes: trigger 2 New notes: trigger 3']}, 'from_email': 'MERMAID System <sysadmin@datamermaid.org>', 'reply_to': ['alain@sparkgeo.com', 'alain@alainstpierre.com']}] at 2023-02-01T20:12:00.225834
simpleq: Finished job _mermaid_email at 2023-02-01T20:12:00.296621 in 0.070787 seconds.
simpleq: Starting job update_project_summaries with args [{'project_id': UUID('a53f6169-a278-4caf-ba03-8e7e38838d52')}] at 2023-02-01T20:12:00.319054
simpleq: Finished job update_project_summaries at 2023-02-01T20:12:01.414432 in 1.095378 seconds.
```