### PR TITLE
Queue worker construct

### DIFF
--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -269,7 +269,7 @@ class ApiStack(Stack):
         # get monitored queue
         worker = QueueWorker(
             self,
-            "QueueWorker",
+            "Worker",
             config=config,
             cluster=cluster,
             image_asset=image_asset,
@@ -283,9 +283,6 @@ class ApiStack(Stack):
         # allow API to send messages to the queue
         worker.queue.grant_send_messages(service.task_definition.task_role)
 
-        # allow Worker to read messages from the queue
-        # worker.queue.grant_send_messages(sqs_worker_service.task_definition.task_role)
-
-        # allow Tasks (API/SQS) to read/write to the public bucket
+        # allow API to read/write to the public bucket
         public_bucket.grant_read_write(service.task_definition.task_role)
         

--- a/iac/stacks/constructs/monitored_queue.py
+++ b/iac/stacks/constructs/monitored_queue.py
@@ -1,0 +1,91 @@
+from constructs import Construct
+from aws_cdk import (
+    Duration,
+    aws_sqs as sqs,
+    aws_cloudwatch as cw,
+    aws_cloudwatch_actions as cw_actions,
+    aws_sns as sns,
+    aws_sns_subscriptions as sns_subs,
+)
+
+from iac.settings.settings import ProjectSettings
+
+class MonitoredQueue(Construct):
+    def __init__(
+        self, 
+        scope: Construct, 
+        id: str, 
+        config: ProjectSettings,
+        email: str = None,
+        **kwargs,
+    ) -> None:
+        
+        super().__init__(scope, id, **kwargs)
+
+        # DLQ
+        dead_letter_queue = sqs.Queue(
+            self,
+            "DeadLetterQueue",
+            queue_name=f"mermaid-{config.env_id}-deadletter",
+            retention_period=Duration.days(7),
+        )
+
+        # FIFO Queue
+        queue = sqs.Queue(
+            self,
+            "FifoQueue",
+            fifo=True,
+            queue_name=f"mermaid-{config.env_id}.fifo",
+            content_based_deduplication=False,
+            visibility_timeout=Duration.seconds(config.api.sqs_message_visibility),
+            dead_letter_queue=sqs.DeadLetterQueue(
+                max_receive_count=3, 
+                queue=dead_letter_queue
+            ),
+        )
+
+        # CloudWatch Alarm for Queue
+        # Issue alarm when message is older than 15 mins in queue
+        alarm_when_message_older_than = 15
+        queue_alarm = cw.Alarm(
+            self,
+            "QueueAlarm",
+            metric=queue.metric_approximate_age_of_oldest_message(
+                statistic="Maximum",
+                period=Duration.minutes(1),
+            ),
+            threshold=alarm_when_message_older_than,
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=cw.TreatMissingData.IGNORE,
+        )
+
+        # CloudWatch Alarm for DLQ
+        dlq_alarm = cw.Alarm(
+            self,
+            "DLQAlarm",
+            metric=queue.metric_approximate_number_of_messages_visible(
+                statistic="Maximum",
+            ),
+            threshold=1,
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=cw.TreatMissingData.IGNORE,
+        )
+
+        # SNS Topic & Subscription
+        topic = sns.Topic(self, "Topic")
+        if email:
+            topic.add_subscription(sns_subs.EmailSubscription(email))
+
+        # Add SNS Action to CloudWatch Alarms
+        sns_action = cw_actions.SnsAction(topic=topic)
+
+        queue_alarm.add_alarm_action(sns_action)
+        queue_alarm.add_ok_action(sns_action)
+
+        dlq_alarm.add_alarm_action(sns_action)
+        dlq_alarm.add_ok_action(sns_action)
+
+        # export the main queue
+        self.queue = queue

--- a/iac/stacks/constructs/worker.py
+++ b/iac/stacks/constructs/worker.py
@@ -77,7 +77,7 @@ class QueueWorker(Construct):
         dlq_alarm = cw.Alarm(
             self,
             "DLQAlarm",
-            metric=queue.metric_approximate_number_of_messages_visible(
+            metric=dead_letter_queue.metric_approximate_number_of_messages_visible(
                 statistic="Maximum",
             ),
             threshold=1,
@@ -130,4 +130,3 @@ class QueueWorker(Construct):
 
         # exports
         self.queue = queue
-        # self.fargate_service = fargate_service


### PR DESCRIPTION
I've refactored the api.py so that all of the "worker" resources are encapsulated into it's own construct. Please pay attention to the `cdk diff` in the comments after the diff runs.

### 🚨 PLEASE NOTE 🚨
This will tear down the existing SQS Queue so any message in the queue will be lost.