### PR TITLE
M688 - Enable ECS managed EC2 autoscaling.

### DIFF
--- a/iac/install_cdk.sh
+++ b/iac/install_cdk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-CDK_VERSION=2.44.0
+CDK_VERSION=2.131.0
 
 echo "Installing AWS CDK CLI"
 npm install -g aws-cdk@$CDK_VERSION

--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -174,14 +174,18 @@ class ApiStack(Stack):
             security_groups=[container_security_group],
             desired_count=config.api.container_count,
             enable_execute_command=True,
+            capacity_provider_strategies=[
+                ecs.CapacityProviderStrategy(
+                    capacity_provider="mermaid-api-infra-common-AsgCapacityProvider760D11D9-iqzBF6LfX313",
+                    weight=100,
+                )
+            ],
         )
 
         # Grant Secret read to API container & backup task
         for _, container_secret in api_secrets.items():
             container_secret.grant_read(service.task_definition.execution_role)
             container_secret.grant_read(backup_task.task_definition.execution_role)
-
-        # add FargateService as target to LoadBalancer/Listener, currently, send all traffic. TODO filter by domain?
 
         target_group = elb.ApplicationTargetGroup(
             self,

--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -5,6 +5,7 @@ from aws_cdk import (
     Duration,
     RemovalPolicy,
     Stack,
+    aws_autoscaling as autoscale,
     aws_certificatemanager as acm,
     aws_ec2 as ec2,
     aws_ecs as ecs,
@@ -159,17 +160,33 @@ class CommonStack(Stack):
             enable_fargate_capacity_providers=True,
             execute_command_configuration=ecs_exec_config,
         )
-        self.cluster.add_capacity(
-            "DefaultAutoScalingGroupCapacity",
-            instance_type=ec2.InstanceType("t3.medium"),
-            desired_capacity=1,
-            max_capacity=6,
+
+        auto_scaling_group = autoscale.AutoScalingGroup(
+            self,
+            "ASG",
+            vpc=self.vpc,
+            instance_type=ec2.InstanceType("t3a.large"),
+            machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             min_capacity=1,
-            vpc_subnets=ec2.SubnetSelection(
-                subnets=self.cluster.vpc.select_subnets(
-                    subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT
-                ).subnets
-            ),
+            max_capacity=4,
+            # NOTE: not setting the desired capacity so ECS can manage it.
+        )
+
+        capacity_provider = ecs.AsgCapacityProvider(
+            self,
+            "AsgCapacityProvider",
+            auto_scaling_group=auto_scaling_group,
+            enable_managed_scaling=True,
+            enable_managed_termination_protection=False,
+        )
+        self.cluster.add_asg_capacity_provider(capacity_provider)
+
+        self.cluster.add_default_capacity_provider_strategy(
+            [
+                ecs.CapacityProviderStrategy(
+                    capacity_provider=capacity_provider.capacity_provider_name, weight=100
+                )
+            ]
         )
 
         self.load_balancer = elb.ApplicationLoadBalancer(

--- a/iac/stacks/constructs/worker.py
+++ b/iac/stacks/constructs/worker.py
@@ -98,6 +98,12 @@ class QueueWorker(Construct):
                 # when >=1 messages, scale up
                 appscaling.ScalingInterval(lower=1, change=+1),
             ],
+            "capacity_provider_strategies": [
+                ecs.CapacityProviderStrategy(
+                    capacity_provider="mermaid-api-infra-common-AsgCapacityProvider760D11D9-iqzBF6LfX313",
+                    weight=100,
+                )
+            ],
         }
 
         if config.env_id == "dev":


### PR DESCRIPTION
This change creates an autoscale group and assigns it as a Capacity Provider Strategy, which will allow ECS to manage the number of instances. 

Note: The scale-out works when there are containers that need to be scheduled. However, here is a scenario where it won't work as intended:

- An ECS service A get's scaled up, and more EC2 instances are required, ECS will tell the ASG to add another instance. 
- Then, ECS service A get's scaled down, ECS removes containers to suit, and in many cases will leave a container on each instance. 
- Even though all the now running containers can fit on one instance, ECS won't scale-in the EC2 instances because there are containers running on them. 

To solve this, we would have to look into modifying the scheduler, reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_replica

Also, Service autoscaling is not enabled on the API service, however, the worker service will scale from 0 to 1, and the backup task will run once a day. See PR #344 for the API autoscaling implementation.
