### PR TITLE
[M783] Support FIFO and standard queues with simple q

### DIFF
--- a/src/simpleq/queues.py
+++ b/src/simpleq/queues.py
@@ -104,14 +104,17 @@ class Queue:
         try:
             self._queue = self.sqs_resource.get_queue_by_name(QueueName=queue_name)
         except self.sqs_resource.meta.client.exceptions.QueueDoesNotExist:
-            # TODO: leave this for now until we sort out local
+            queue_attributes = {
+                "VisibilityTimeout": str(self.SQS_MESSAGE_VISIBILITY),
+                "FifoQueue": "false",
+            }
+            if self.USE_FIFO:
+                queue_attributes["FifoQueue"] = "true"
+                queue_attributes["ContentBasedDeduplication"] = "false"
+
             self._queue = self.sqs_resource.create_queue(
                 QueueName=queue_name,
-                Attributes={
-                    "VisibilityTimeout": str(self.SQS_MESSAGE_VISIBILITY),
-                    "FifoQueue": "true" if self.USE_FIFO else "false",
-                    "ContentBasedDeduplication": "false",
-                },
+                Attributes=queue_attributes,
             )
 
         return self._queue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `USE_FIFO` setting for FIFO (First In, First Out) queue ordering.
  - Conditional inclusion of `MessageDeduplicationId` and `MessageGroupId` attributes in job messages based on the FIFO setting.

- **Improvements**
  - Enhanced logic for creating AWS SQS queues with conditional attribute settings for better flexibility and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->