### PR TITLE
[M790] Allow non-admin read access to indicator sets

### DIFF
--- a/src/api/resources/gfcr.py
+++ b/src/api/resources/gfcr.py
@@ -3,8 +3,10 @@ import uuid
 from datetime import datetime
 
 from django.db import transaction
+from rest_condition import Or
 from rest_framework import serializers, status
 from rest_framework.response import Response
+
 
 from ..models import (
     GFCRFinanceSolution,
@@ -13,7 +15,7 @@ from ..models import (
     GFCRRevenue,
     RestrictedProjectSummarySampleEvent,
 )
-from ..permissions import ProjectDataAdminPermission
+from ..permissions import ProjectDataAdminPermission, ProjectDataReadOnlyPermission
 from .base import BaseAPISerializer, BaseProjectApiViewSet
 
 BENTHIC_LIT = "benthiclit"
@@ -148,9 +150,15 @@ class GFCRIndicatorSetSerializer(BaseAPISerializer):
 class IndicatorSetViewSet(BaseProjectApiViewSet):
     serializer_class = GFCRIndicatorSetSerializer
     project_lookup = "project"
-    permission_classes = [ProjectDataAdminPermission]
+    permission_classes = [
+        Or(
+            ProjectDataAdminPermission,
+            ProjectDataReadOnlyPermission
+        )
+    ]
 
     def get_queryset(self):
+        print(self.request.user.profile)
         project_id = self.kwargs.get("project_pk")
         if project_id is None:
             return GFCRIndicatorSet.objects.none()

--- a/src/api/tests/test_gfcr.py
+++ b/src/api/tests/test_gfcr.py
@@ -7,6 +7,7 @@ from api.models import (
     GFCRFinanceSolution,
     GFCRIndicatorSet,
     GFCRRevenue,
+    ProjectProfile,
     RestrictedProjectSummarySampleEvent,
 )
 
@@ -109,7 +110,7 @@ def restricted_project_summary_sample_events(
     )
 
 
-def test_create_indicator_set(
+def test_create_indicator_set_admin(
     db_setup,
     api_client1,
     project1,
@@ -141,6 +142,21 @@ def test_create_indicator_set(
     revenue_data = finance_solution_data["revenues"][0]
     assert revenue_data["id"] is not None
     assert str(revenue.pk) == revenue_data["id"]
+
+
+def test_create_indicator_set_non_admin(
+    db_setup,
+    api_client1,
+    project1,
+    project_profile1,
+    create_indicator_set_payload,
+):
+    project_profile1.role = ProjectProfile.COLLECTOR
+    project_profile1.save()
+    url = reverse("indicatorset-list", kwargs={"project_pk": project1.pk})
+    request = api_client1.post(url, data=create_indicator_set_payload, format="json")
+
+    assert request.status_code == 403
 
 
 def test_update_indicator_set(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced read-only access permissions for indicator sets, allowing non-admin users to view data without making changes.

- **Tests**
  - Added tests to ensure non-admin users can create indicator sets under the new read-only permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->