### PR TITLE
M942 Update DLQ Config

### DIFF
--- a/iac/settings/dev.py
+++ b/iac/settings/dev.py
@@ -20,7 +20,7 @@ DEV_SETTINGS = ProjectSettings(
         default_domain_collect="https://dev-app.datamermaid.org",
         mermaid_api_audience="https://dev-api.datamermaid.org",
         public_bucket="dev-public.datamermaid.org",
-        sqs_message_visibility=1800,
+        sqs_message_visibility=600,
         # Secrets
         dev_emails_name="dev/mermaid-api/dev-emails-mUnSDl",
         spa_admin_client_id_name="common/mermaid-api/spa-admin-client-id-FuMVtc",

--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -126,6 +126,7 @@ class ApiStack(Stack):
             "DB_PORT": config.database.port,
             "SQS_MESSAGE_VISIBILITY": str(config.api.sqs_message_visibility),
             "USE_FIFO": use_fifo_queues,
+            "SQS_QUEUE_NAME": sqs_queue_name,
         }
 
         # build image asset to be shared with API and Backup Task
@@ -258,7 +259,6 @@ class ApiStack(Stack):
         backup_bucket.grant_read_write(backup_task.task_definition.task_role)
 
         # get monitored queue
-        environment["SQS_QUEUE_NAME"] = sqs_queue_name
         worker = QueueWorker(
             self,
             "Worker",

--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -173,7 +173,7 @@ class CommonStack(Stack):
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             min_capacity=1,
             max_capacity=4,
-            max_instance_lifetime=Duration.days(1),
+            max_instance_lifetime=Duration.days(7),
             update_policy=autoscale.UpdatePolicy.rolling_update(),
             # NOTE: not setting the desired capacity so ECS can manage it.
         )

--- a/iac/stacks/constructs/worker.py
+++ b/iac/stacks/constructs/worker.py
@@ -52,7 +52,7 @@ class QueueWorker(Construct):
             queue_name=f"{queue_name}.fifo" if fifo else f"{queue_name}",
             content_based_deduplication=None,
             visibility_timeout=Duration.seconds(config.api.sqs_message_visibility),
-            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=dead_letter_queue),
+            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=4, queue=dead_letter_queue),
         )
 
         # CloudWatch Alarm for DLQ


### PR DESCRIPTION
This PR is a result from a discussion in Slack. 

The changes include:
- Changing the `max_receive_count` for the DLQ will increase the number of times a failed job "retried".
- Changing the `visibility_timeout` will allow failed messages to be retried quicker. 

Other changes:
- Incorrect queue name, which should solve M953 (TBC).
- In a previous PR instance maximum age was set to 1 day to test it would operate as expected. This is operating as expected, so bumping it up to the desired 7 days. 