### PR TITLE
[M978] Remove revision related to profile if added back to project

### DIFF
--- a/src/api/models/revisions.py
+++ b/src/api/models/revisions.py
@@ -115,6 +115,40 @@ class Revision(models.Model):
         return cls.create(
             table_name, record_id, project_id, profile_id, deleted, related_to_profile_id
         )
+    
+    
+    @classmethod
+    def remove(
+        cls,
+        table_name,
+        record_id,
+        project_id=None,
+        profile_id=None,
+        deleted=False,
+        related_to_profile_id=None,
+    ):
+        Revision.objects.filter(
+            table_name=table_name,
+            record_id=record_id,
+            project_id=project_id,
+            profile_id=profile_id,
+            deleted=deleted,
+            related_to_profile_id=related_to_profile_id,
+        ).delete()
+    
+
+    @classmethod
+    def remove_from_instance(
+        cls, instance, profile_id=None, deleted=False, related_to_profile_id=None
+    ):
+        table_name = instance._meta.db_table
+        record_id = instance.pk
+        project_id = cls._get_project_id(instance)
+
+        return cls.remove(
+            table_name, record_id, project_id, profile_id, deleted, related_to_profile_id
+        )
+        
 
 
 # -- TRIGGER SQL --

--- a/src/api/signals/revision.py
+++ b/src/api/signals/revision.py
@@ -70,6 +70,13 @@ def delete_project_profile_revisions(sender, instance, *args, **kwargs):
     Revision.create_from_instance(instance.project, related_to_profile_id=instance.profile.pk)
 
 
+@receiver(post_save, sender=ProjectProfile)
+def new_project_profile_revisions(sender, instance, created, *args, **kwargs):
+    if created:
+        Revision.remove_from_instance(instance, related_to_profile_id=instance.profile.pk)
+        Revision.remove_from_instance(instance.project, related_to_profile_id=instance.profile.pk)
+
+
 @receiver(post_save, sender=CollectRecord)
 def new_collect_record_revisions(sender, instance, created, *args, **kwargs):
     if created:

--- a/src/api/tests/test_revision_pull.py
+++ b/src/api/tests/test_revision_pull.py
@@ -157,3 +157,23 @@ def test_removed_from_project(db_setup, profile1, project_profile1):
     assert len(updates) == 0
     assert len(deletes) == 0
     assert len(removes) == 1
+
+
+def test_added_removed_added_to_project(db_setup, project1, profile1):
+    request = MockRequest(profile=profile1)
+    project_viewset = ProjectViewSet(request=request)
+
+    # Add
+    project_profile1 = ProjectProfile.objects.create(project=project1, profile=profile1, role=ProjectProfile.COLLECTOR)
+    # Delete
+    project_profile1.delete()
+    # Re-Add
+    ProjectProfile.objects.create(project=project1, profile=profile1, role=ProjectProfile.COLLECTOR)
+
+    updates, deletes, removes = get_records(
+        project_viewset, profile1.pk, None
+    )
+    
+    assert len(updates) == 1
+    assert len(deletes) == 0
+    assert len(removes) == 0

--- a/src/api/utils/replace.py
+++ b/src/api/utils/replace.py
@@ -70,6 +70,12 @@ def replace_collect_record_owner(project_id, from_profile, to_profile, updated_b
             deleted=False,
             related_to_profile_id=from_profile.pk,
         )
+        Revision.remove_from_instance(
+            instance=collect_record,
+            profile_id=to_profile.pk,
+            deleted=False,
+            related_to_profile_id=to_profile.pk,
+        )
 
         collect_record.pk = None
         collect_record.profile = to_profile


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for removing revisions associated with project profiles, enhancing record management capabilities.
	- Added signal handling to clean up irrelevant revisions upon the creation of a new project profile.
  
- **Bug Fixes**
	- Improved data integrity by ensuring that existing revisions are properly removed before updating profile ownership in records.

- **Tests**
	- Added tests to verify the functionality of adding, deleting, and re-adding project profiles, ensuring the system tracks these changes accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->