### PR TITLE
Update ALB idle timeout.

### DIFF
--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -240,6 +240,7 @@ class CommonStack(Stack):
             vpc=self.vpc,
             internet_facing=True,
             deletion_protection=True,
+            idle_timeout=Duration.seconds(300),  # To match webserver timeout
         )
 
         # DNS setup


### PR DESCRIPTION
The API is seeing some requests timeout after ~60s. This PR increases the load balancer idle timeout to match Gunicorn, which is 300s. 