### PR TITLE
[M569] Process covariates in background worker

### DIFF
--- a/src/api/covariates/__init__.py
+++ b/src/api/covariates/__init__.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
-from ..decorators import run_in_thread
 from ..models import Covariate
+from ..utils.q import submit_job
 from .coral_atlas import CoralAtlasCovariate
 from .vibrant_oceans import VibrantOceansThreatsCovariate
 
@@ -119,6 +119,5 @@ def update_site_covariates(site):
         update_site_vot_covariates(site)
 
 
-@run_in_thread
-def update_site_covariates_threaded(site):
-    update_site_covariates(site)
+def update_site_covariates_bg_process(site):
+    submit_job(0, True, update_site_covariates, site)

--- a/src/api/decorators.py
+++ b/src/api/decorators.py
@@ -1,5 +1,4 @@
 import functools
-import threading
 import time
 
 from django.utils.translation import gettext as _
@@ -30,11 +29,3 @@ def needs_instance(message):
         return wrapped
 
     return _needs_instance
-
-
-def run_in_thread(fn):
-    def run(*k, **kw):
-        t = threading.Thread(target=fn, args=k, kwargs=kw)
-        t.start()
-
-    return run

--- a/src/api/signals/__init__.py
+++ b/src/api/signals/__init__.py
@@ -6,7 +6,7 @@ from django.core import serializers
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
-from ..covariates import update_site_covariates_threaded
+from ..covariates import update_site_covariates_bg_process
 from ..models import (
     ArchivedRecord,
     BaseModel,
@@ -123,6 +123,6 @@ def run_management_validation(sender, instance, *args, **kwargs):
         instance.updated_on = mgmt.updated_on
 
 
-@receiver(pre_save, sender=Site)
+@receiver(post_save, sender=Site)
 def update_with_covariates(sender, instance, *args, **kwargs):
-    update_site_covariates_threaded(instance)
+    update_site_covariates_bg_process(instance)


### PR DESCRIPTION
This pull request includes several changes to improve the background processing of site covariates by replacing threading with a job submission utility. The most important changes include the removal of the `run_in_thread` decorator, the addition of the `submit_job` utility, and the update of signal handlers to use the new background processing function.

Improvements to background processing:

* [`src/api/covariates/__init__.py`](diffhunk://#diff-8de85792706125af7c35cd35fb75bc00ece4ba0b2439dbe25bd5d178afa3a92eL3-R4): Removed the `run_in_thread` decorator and replaced it with the `submit_job` utility for background processing in the `update_site_covariates_bg_process` function. [[1]](diffhunk://#diff-8de85792706125af7c35cd35fb75bc00ece4ba0b2439dbe25bd5d178afa3a92eL3-R4) [[2]](diffhunk://#diff-8de85792706125af7c35cd35fb75bc00ece4ba0b2439dbe25bd5d178afa3a92eL122-R123)
* [`src/api/decorators.py`](diffhunk://#diff-b7fa29107f8037615e1770e11d630b2e11db005d22683d91d9f5b98e72d118f3L2): Removed the `run_in_thread` decorator and its associated threading logic. [[1]](diffhunk://#diff-b7fa29107f8037615e1770e11d630b2e11db005d22683d91d9f5b98e72d118f3L2) [[2]](diffhunk://#diff-b7fa29107f8037615e1770e11d630b2e11db005d22683d91d9f5b98e72d118f3L33-L40)

Updates to signal handlers:

* [`src/api/signals/__init__.py`](diffhunk://#diff-b27ee48e04ff431f77022fdbf2aa35602c8a4909326cad84a72ab3f8c54e1004L9-R9): Updated the import to use `update_site_covariates_bg_process` instead of `update_site_covariates_threaded`, and modified the signal handler to use the new function. [[1]](diffhunk://#diff-b27ee48e04ff431f77022fdbf2aa35602c8a4909326cad84a72ab3f8c54e1004L9-R9) [[2]](diffhunk://#diff-b27ee48e04ff431f77022fdbf2aa35602c8a4909326cad84a72ab3f8c54e1004L126-R128)