### PR TITLE
[M1471] make xlsx report filenames include times; fix synchronous name

### DIFF
--- a/src/api/utils/__init__.py
+++ b/src/api/utils/__init__.py
@@ -172,9 +172,13 @@ def truthy(val):
     return val in ("t", "T", "true", "True", True, 1)
 
 
-def create_iso_date_string(delimiter="-"):
+def create_iso_date_string(delimiter="-", include_time=False):
+    now = timezone.now()
     date_format = f"%y{delimiter}%m{delimiter}%d"
-    return timezone.now().strftime(date_format)
+    if include_time:
+        milliseconds = int(now.microsecond / 1000)
+        date_format += f"_%H%M%S_{milliseconds:03d}"
+    return now.strftime(date_format)
 
 
 def create_timestamp(ttl=0):

--- a/src/api/utils/email.py
+++ b/src/api/utils/email.py
@@ -142,7 +142,7 @@ def email_report(to_email, local_file_path, protocol):
     try:
         zip_file_path = None
         local_file_path = Path(local_file_path)
-        file_name = f"{create_iso_date_string()}_{protocol}.xlsx"
+        file_name = f"{create_iso_date_string(include_time=True)}_{protocol}.xlsx"
         s3_zip_file_key = f"{settings.ENVIRONMENT}/reports/{file_name}.zip"
 
         zip_file_path = local_file_path.with_name(f"{file_name}.zip")

--- a/src/api/utils/reports.py
+++ b/src/api/utils/reports.py
@@ -59,7 +59,9 @@ def create_sample_unit_method_summary_report(
 
     with NamedTemporaryFile(delete=False) as f:
         temppath = Path(f.name)
-        output_path = temppath.rename(f"{temppath.parent}/{create_iso_date_string()}_gfcr.xlsx")
+        output_path = temppath.rename(
+            f"{temppath.parent}/{create_iso_date_string()}_{protocol}.xlsx"
+        )
         wb = create_protocol_report(request, project_ids, protocol)
         try:
             wb.save(output_path)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Filenames for exported reports now include both the date and time for improved clarity and uniqueness.
	- Report filenames dynamically reflect the protocol used, providing more descriptive file names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->