### PR TITLE
test sagemaker stack in cluster vpc with public subnets

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -28,12 +28,12 @@ jobs:
     needs: [call-test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4.2.0
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: '^22.11.0'
 
       - name: Setup Python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "^3.12.0"
 
@@ -44,7 +44,7 @@ jobs:
           iac/install_cdk.sh
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.1.0
+        uses: aws-actions/configure-aws-credentials@v4.2.1
         env:
           CDK_DEFAULT_ACCOUNT: ${{ secrets.CDK_DEFAULT_ACCOUNT }}
           DEPLOY_AWS_ROLE: ${{ secrets.DEPLOY_AWS_ROLE }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,23 +30,23 @@ jobs:
     needs: [call-test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: '^22.11.0'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "^3.12.0"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
 
       - name: Install CDK
         run: |
           cd iac && ./install_cdk.sh
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.1.0
+        uses: aws-actions/configure-aws-credentials@v4.2.1
         env:
           CDK_DEFAULT_ACCOUNT: ${{ secrets.CDK_DEFAULT_ACCOUNT }}
           DEPLOY_AWS_ROLE: ${{ secrets.DEPLOY_AWS_ROLE }}

--- a/README.md
+++ b/README.md
@@ -15,26 +15,28 @@
 
 ## Local Development Workflow
 
-Common workflow tasks are wrapped up using [Fabric](http://www.fabfile.org/) commands. Refer to `fabfile.py` for the 
+Common workflow tasks are wrapped up using [Fabric](http://www.fabfile.org/) commands. Refer to `fabfile.py` for the
 current commands. Add commands as required.
 
 ## Local Development Setup
 
 ### Installation
 
-This project uses Docker for configuring the development environment and managing it. By overriding the container's 
+This project uses Docker for configuring the development environment and managing it. By overriding the container's
 environment variables, the same Docker image can be used for the production service. Thus, for development work, you
- must have Docker installed and running. 
- 
-Note that the following covers only local configuration, not deployment. See the 
+must have Docker installed and running.
+
+Note that the following covers only local configuration, not deployment. See the
 [IAC README](iac/README.md) in this repository for more information.
- 
+
 ### Environment variables
 
-1. copy the sample `.secrets.env.sample` file and fill in the blanks: 
+1. copy the sample `.secrets.env.sample` file and fill in the blanks:
+
 - `cp .secrets.env.sample .secrets.env`
 
-2. copy the sample `.env.sample` file and fill in the blanks: 
+2. copy the sample `.env.sample` file and fill in the blanks:
+
 - `cp .env.sample .env`
 
 ### Local environment initialization
@@ -59,22 +61,28 @@ $ fab build
 $ fab up
 ```
 
-If this is the first time running the up command, the api image will be built and postgis image will be downloaded. 
-Then the containers will be started. 
+If this is the first time running the up command, the api image will be built and postgis image will be downloaded.
+Then the containers will be started.
 
-With a database already created and persisted in an S3 bucket via 
+With a database already created and persisted in an S3 bucket via
+
 ```sh
 $ fab dbbackup
-``` 
+```
+
 ,
+
 ```sh
 $ fab dbrestore
-``` 
+```
+
 will recreate and populate the local database with the latest dump. Without the S3 dump (i.e. running for the first time),
- you'll need to create a local database and then run 
- ```sh
+you'll need to create a local database and then run
+
+```sh
 $ fab migrate
-``` 
+```
+
 to create its schema.
 
 A shortcut for the above steps, once S3 is set up, is available via:
@@ -95,10 +103,10 @@ $ fab runserver
 
 ### Further
 
-The project directory `api` is mounted to the container, so any changes you make outside the container (e.g. using 
+The project directory `api` is mounted to the container, so any changes you make outside the container (e.g. using
 an IDE installed on your host OS) are available inside the container.
 
-Please note that running `fab up` does NOT rebuild the image. So if you are making changes to the Dockerfile, for 
+Please note that running `fab up` does NOT rebuild the image. So if you are making changes to the Dockerfile, for
 example adding a dependency to the `requirement.txt` file, you will need to do the following:
 
 ```
@@ -127,22 +135,21 @@ env: local, dev, prod
 
 ## Related repos
 
-The MERMAID API forms the backbone for a growing family of apps that allow for coral reef data collection, 
+The MERMAID API forms the backbone for a growing family of apps that allow for coral reef data collection,
 management and reporting, and visualization:
 https://github.com/data-mermaid
 
 ## Contributing
 
-Pull Requests welcome! When we move to Python 3 this repo will use [Black](https://black.readthedocs.io/en/stable/). Send development questions to 
+Pull Requests welcome! When we move to Python 3 this repo will use [Black](https://black.readthedocs.io/en/stable/). Send development questions to
 admin@datamermaid.org.
-
 
 ## Other Topics
 
 ### Collect Record
 
-* [Push/Pull](src/api/resources/sync/README.md)
-* [Validations v2](src/api/submission/validations2/README.md)
+- [Push/Pull](src/api/resources/sync/README.md)
+- [Validations v2](src/api/submission/validations2/README.md)
 
 ### SSH into containers in the cloud
 
@@ -157,3 +164,16 @@ admin@datamermaid.org.
 - su webapp
 - bash
 
+## Sagemaker AI
+
+1. Dev URL: https://d-5ls5xpurmpfg.studio.us-east-1.sagemaker.aws/
+2. AWS Sagemaker Domain Deployment: https://us-east-1.console.aws.amazon.com/sagemaker/home?region=us-east-1#/studio/d-5ls5xpurmpfg
+3. Adding users and groups: https://us-east-1.console.aws.amazon.com/sagemaker/home?region=us-east-1#/studio/d-5ls5xpurmpfg?tab=users
+4. Source buckets:
+5. dev-datamermaid-sm-sources: https://us-east-1.console.aws.amazon.com/s3/buckets/dev-datamermaid-sm-sources?region=us-east-1&bucketType=general&tab=objects
+6. mermaid-image-processing: https://us-east-1.console.aws.amazon.com/s3/buckets/mermaid-image-processing?region=us-east-1&bucketType=general&tab=objects
+7. datamermaid-coral-reef-training:
+8. Output bucket:
+9. dev-datamermaid-sm-data: http://us-east-1.console.aws.amazon.com/s3/buckets/dev-datamermaid-sm-data?region=us-east-1&tab=objects&bucketType=general
+10. To add bucket access either pre existing one or creating a new one, depending on the requirements allow the sagemaker execution to read and/or write to the bucket. Examples can be found in `iac/stacks/sagemaker.py`
+11. Currently we have a single dev deployment: https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=&filteringStatus=active&viewNested=true&stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A554812291621%3Astack%2Fdev-mermaid-sagemaker%2Fb124dad0-32b4-11f0-bc6d-0affe30c0943

--- a/iac/app.py
+++ b/iac/app.py
@@ -6,6 +6,7 @@ from settings.prod import PROD_SETTINGS
 from stacks.api import ApiStack
 from stacks.common import CommonStack
 from stacks.github_access import GithubAccessStack
+from stacks.sagemaker import SagemakerStack
 from stacks.static_site import StaticSiteStack
 
 tags = {
@@ -64,6 +65,15 @@ dev_api_stack = ApiStack(
     public_bucket=dev_static_site_stack.site_bucket,
     image_processing_bucket=common_stack.image_processing_bucket,
     use_fifo_queues="False",
+)
+
+dev_sagemaker_stack = SagemakerStack(
+    app,
+    "dev-mermaid-sagemaker",
+    env=cdk_env,
+    tags=tags,
+    config=DEV_SETTINGS,
+    cluster=common_stack.cluster,
 )
 
 prod_static_site_stack = StaticSiteStack(

--- a/iac/app.py
+++ b/iac/app.py
@@ -74,6 +74,7 @@ dev_sagemaker_stack = SagemakerStack(
     tags=tags,
     config=DEV_SETTINGS,
     cluster=common_stack.cluster,
+    database=common_stack.database,
 )
 
 prod_static_site_stack = StaticSiteStack(

--- a/iac/app.py
+++ b/iac/app.py
@@ -74,7 +74,6 @@ dev_sagemaker_stack = SagemakerStack(
     tags=tags,
     config=DEV_SETTINGS,
     cluster=common_stack.cluster,
-    database=common_stack.database,
 )
 
 prod_static_site_stack = StaticSiteStack(

--- a/iac/cdk.context.json
+++ b/iac/cdk.context.json
@@ -23,5 +23,37 @@
   },
   "acknowledged-issue-numbers": [
     32775
+  ],
+  "endpoint-service-availability-zones:account=554812291621:region=us-east-1:serviceName=com.amazonaws.us-east-1.sagemaker.api": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
+  ],
+  "endpoint-service-availability-zones:account=554812291621:region=us-east-1:serviceName=aws.sagemaker.us-east-1.notebook": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
+  ],
+  "endpoint-service-availability-zones:account=554812291621:region=us-east-1:serviceName=com.amazonaws.us-east-1.sagemaker.runtime": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
+  ],
+  "endpoint-service-availability-zones:account=554812291621:region=us-east-1:serviceName=aws.sagemaker.us-east-1.studio": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
   ]
 }

--- a/iac/install_cdk.sh
+++ b/iac/install_cdk.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 set -e
 
-CDK_VERSION=2.167.1
+CDK_CLI_VERSION=2.1016.0
+CDK_LIB_VERSION=2.196.1
 
 echo "Installing AWS CDK CLI"
-npm install -g aws-cdk@$CDK_VERSION
+npm install -g aws-cdk@$CDK_CLI_VERSION
 
 echo "Installing AWS CDK Python Libs"
-pip install aws-cdk-lib==$CDK_VERSION
+pip install aws-cdk-lib==$CDK_LIB_VERSION
 

--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -283,10 +283,10 @@ class CommonStack(Stack):
 
         self.security_group = ec2.SecurityGroup(
             self,
-            "SagemakerSecurityGroup",
+            "VPCEndpointSagemaker",
             vpc=self.vpc,
             allow_all_outbound=True,
-            description="Security group for SageMaker Studio",
+            description="Security group for SageMaker VPC endpoints",
         )
 
         for service_name in [
@@ -306,7 +306,7 @@ class CommonStack(Stack):
                     subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS,
                     one_per_az=True,
                 ),
-                security_groups=[self.ecs_sg, self.security_group],
+                security_groups=[self.security_group],
                 dns_record_ip_type=ec2.VpcEndpointDnsRecordIpType.IPV4,
                 ip_address_type=ec2.VpcEndpointIpAddressType.IPV4,
                 private_dns_enabled=True,

--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -281,6 +281,39 @@ class CommonStack(Stack):
 
         create_cdk_bot_user(self, self.account)
 
+        self.security_group = ec2.SecurityGroup(
+            self,
+            "SagemakerSecurityGroup",
+            vpc=self.vpc,
+            allow_all_outbound=True,
+            description="Security group for SageMaker Studio",
+        )
+
+        for service_name in [
+            "SAGEMAKER_API",
+            "SAGEMAKER_NOTEBOOK",
+            "SAGEMAKER_RUNTIME",
+            "SAGEMAKER_STUDIO",
+        ]:
+            self.vpc.add_interface_endpoint(
+                f"{service_name}VpcEndpoint",
+                service=getattr(
+                    ec2.InterfaceVpcEndpointAwsService,
+                    service_name,
+                ),
+                lookup_supported_azs=True,
+                subnets=ec2.SubnetSelection(
+                    subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                    one_per_az=True,
+                ),
+                security_groups=[self.ecs_sg, self.security_group],
+                dns_record_ip_type=ec2.VpcEndpointDnsRecordIpType.IPV4,
+                ip_address_type=ec2.VpcEndpointIpAddressType.IPV4,
+                private_dns_enabled=True,
+                open=True,
+            )
+
+
 
 def create_cdk_bot_user(self, account: str):
     cdk_policy = iam.Policy(

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -69,6 +69,13 @@ class SagemakerStack(cdk.Stack):
             vpc_id=self.vpc.vpc_id,
             subnet_ids=public_subnet_ids,
         )
+        ssm.StringParameter(
+            self,
+            f"{self.prefix}SagemakerDomainUrl",
+            string_value=self.domain.attr_url,
+            parameter_name=f"/{self.prefix}/SagemakerDomainUrl",
+            description="SageMaker Domain URL",
+        )
 
         # Create SageMaker Studio default user profile
         self.user = sm.CfnUserProfile(
@@ -77,7 +84,10 @@ class SagemakerStack(cdk.Stack):
             domain_id=self.domain.attr_domain_id,
             user_profile_name="default-user",
             user_settings=sm.CfnUserProfile.UserSettingsProperty(),
+            single_sign_on_user_identifier="UserName",  # or "UserProfileName", depending on your SSO setup
+            single_sign_on_user_value="mehul@datamermaid.org",  # set this to the SSO user's username
         )
+
 
     def create_execution_role(self) -> iam.Role:
         role = iam.Role(
@@ -106,13 +116,13 @@ class SagemakerStack(cdk.Stack):
     def create_sm_sources_bucket(self) -> s3.Bucket:
         return self._create_bucket(
             id=f"{self.prefix}SourcesBucket",
-            bucket_name=f"{self.prefix}-mermaid-sm-sources",
+            bucket_name=f"{self.prefix}-datamermaid-sm-sources",
         )
 
     def create_data_bucket(self) -> s3.Bucket:
         return self._create_bucket(
             id=f"{self.prefix}DataBucket",
-            bucket_name=f"{self.prefix}-mermaid-sm-data",
+            bucket_name=f"{self.prefix}-datamermaid-sm-data",
         )
 
     def _create_bucket(self, id: str, bucket_name: str) -> s3.Bucket:

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -112,7 +112,7 @@ class SagemakerStack(cdk.Stack):
             encryption=s3.BucketEncryption.S3_MANAGED,
         )
 
-    def create_data_bucket(self):
+    def create_data_bucket(self) -> s3.Bucket:
         return s3.Bucket(
             self,
             id=f"{self.prefix}DataBucket",

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -73,6 +73,20 @@ class SagemakerStack(cdk.Stack):
                     enable_docker_access="ENABLED",
                 ),
             ),
+            default_space_settings=sm.CfnDomain.DefaultSpaceSettingsProperty(
+                execution_role=self.sm_execution_role.role_arn,
+                space_storage_settings=sm.CfnDomain.DefaultSpaceStorageSettingsProperty(
+                    default_ebs_storage_settings=sm.CfnDomain.DefaultEbsStorageSettingsProperty(
+                        default_ebs_volume_size_in_gb=50,
+                        maximum_ebs_volume_size_in_gb=1000,
+                    ),
+                ),
+                jupyter_lab_app_settings=sm.CfnDomain.JupyterLabAppSettingsProperty(
+                    default_resource_spec=sm.CfnDomain.ResourceSpecProperty(
+                        instance_type="ml.t3.medium",
+                    ),
+                ),
+            ),
         )
 
         CfnOutput(

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -57,7 +57,6 @@ class SagemakerStack(cdk.Stack):
             app_network_access_type="PublicInternetOnly",
             vpc_id=self.vpc.vpc_id,
             subnet_ids=public_subnet_ids,
-            tags=[cdk.CfnTag(key="project", value="example-pipelines")],
         )
 
         # Create SageMaker Studio default user profile
@@ -98,7 +97,6 @@ class SagemakerStack(cdk.Stack):
             self,
             id=f"{self.prefix}SourcesBucket",
             bucket_name=f"{self.prefix}-sm-sources",
-            lifecycle_rules=[],
             versioned=False,
             removal_policy=cdk.RemovalPolicy.DESTROY,
             auto_delete_objects=True,
@@ -110,6 +108,17 @@ class SagemakerStack(cdk.Stack):
             enforce_ssl=True,
             # Encryption
             encryption=s3.BucketEncryption.S3_MANAGED,
+            lifecycle_rules=[
+                s3.LifecycleRule(
+                    expiration=cdk.Duration.days(90),
+                    transitions=[
+                        s3.Transition(
+                            storage_class=s3.StorageClass.INFREQUENT_ACCESS,
+                            transition_after=cdk.Duration.days(30),
+                        )
+                    ],
+                )
+            ],
         )
 
     def create_data_bucket(self) -> s3.Bucket:
@@ -117,7 +126,6 @@ class SagemakerStack(cdk.Stack):
             self,
             id=f"{self.prefix}DataBucket",
             bucket_name=f"{self.prefix}-sm-data",
-            lifecycle_rules=[],
             versioned=False,
             removal_policy=cdk.RemovalPolicy.DESTROY,
             auto_delete_objects=True,
@@ -129,4 +137,15 @@ class SagemakerStack(cdk.Stack):
             enforce_ssl=True,
             # Encryption
             encryption=s3.BucketEncryption.S3_MANAGED,
+            lifecycle_rules=[
+                s3.LifecycleRule(
+                    expiration=cdk.Duration.days(90),
+                    transitions=[
+                        s3.Transition(
+                            storage_class=s3.StorageClass.INFREQUENT_ACCESS,
+                            transition_after=cdk.Duration.days(30),
+                        )
+                    ],
+                )
+            ],
         )

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -177,7 +177,7 @@ class SagemakerStack(cdk.Stack):
             id=id,
             bucket_name=bucket_name,
             versioned=False,
-            removal_policy=cdk.RemovalPolicy.DESTROY,
+            removal_policy=cdk.RemovalPolicy.RETAIN,
             # Access
             access_control=s3.BucketAccessControl.PRIVATE,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -5,6 +5,7 @@ from aws_cdk import (
     aws_s3 as s3,
     aws_sagemaker as sm,
     aws_ssm as ssm,
+    CfnOutput,
 )
 from constructs import Construct
 from settings.settings import ProjectSettings
@@ -33,12 +34,12 @@ class SagemakerStack(cdk.Stack):
         # Create S3 bucket for SageMaker code sources
         self.sm_sources_bucket = self.create_sm_sources_bucket()
 
-        ssm.StringParameter(
+        CfnOutput(
             self,
             f"{self.prefix}SourcesBucketName",
-            string_value=self.sm_sources_bucket.bucket_name,
-            parameter_name=f"/{self.prefix}/SourcesBucketName",
+            value=self.sm_sources_bucket.bucket_name,
             description="SageMaker Sources Bucket Name",
+            export_name=f"{self.prefix}-SourcesBucketName",
         )
 
         # Grant read access to SageMaker execution role
@@ -75,12 +76,20 @@ class SagemakerStack(cdk.Stack):
             ),
         )
 
-        ssm.StringParameter(
+        # ssm.StringParameter(
+        #     self,
+        #     f"{self.prefix}SagemakerDomainUrl",
+        #     string_value=self.domain.attr_url,
+        #     parameter_name=f"/{self.prefix}/SagemakerDomainUrl",
+        #     description="SageMaker Domain URL",
+        # )
+
+        CfnOutput(
             self,
             f"{self.prefix}SagemakerDomainUrl",
-            string_value=self.domain.attr_url,
-            parameter_name=f"/{self.prefix}/SagemakerDomainUrl",
+            value=self.domain.attr_url,
             description="SageMaker Domain URL",
+            export_name=f"{self.prefix}-SagemakerDomainUrl",
         )
 
     def create_execution_role(self) -> iam.Role:
@@ -97,12 +106,19 @@ class SagemakerStack(cdk.Stack):
                 ),
             ],
         )
-        ssm.StringParameter(
+        # ssm.StringParameter(
+        #     self,
+        #     f"{self.prefix}SagemakerExecutionRoleArn",
+        #     string_value=role.role_arn,
+        #     parameter_name=f"/{self.prefix}/SagemakerExecutionRoleArn",
+        #     description="SageMaker Execution Role ARN",
+        # )
+        CfnOutput(
             self,
             f"{self.prefix}SagemakerExecutionRoleArn",
-            string_value=role.role_arn,
-            parameter_name=f"/{self.prefix}/SagemakerExecutionRoleArn",
+            value=role.role_arn,
             description="SageMaker Execution Role ARN",
+            export_name=f"{self.prefix}-SagemakerExecutionRoleArn",
         )
 
         return role

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -105,14 +105,14 @@ class SagemakerStack(cdk.Stack):
 
     def create_sm_sources_bucket(self) -> s3.Bucket:
         return self._create_bucket(
-            id=f"{self.prefix}S3Bucket",
-            bucket_name=f"{self.prefix}-sm-sources",
+            id=f"{self.prefix}SourcesBucket",
+            bucket_name=f"{self.prefix}-mermaid-sm-sources",
         )
 
     def create_data_bucket(self) -> s3.Bucket:
         return self._create_bucket(
             id=f"{self.prefix}DataBucket",
-            bucket_name=f"{self.prefix}-sm-data",
+            bucket_name=f"{self.prefix}-mermaid-sm-data",
         )
 
     def _create_bucket(self, id: str, bucket_name: str) -> s3.Bucket:
@@ -131,6 +131,7 @@ class SagemakerStack(cdk.Stack):
             enforce_ssl=True,
             # Encryption
             encryption=s3.BucketEncryption.S3_MANAGED,
+            # Lifecycle rules
             lifecycle_rules=[
                 s3.LifecycleRule(
                     expiration=cdk.Duration.days(90),

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -1,0 +1,132 @@
+import aws_cdk as cdk
+from aws_cdk import (
+    aws_sagemaker as sm,
+    aws_iam as iam,
+    aws_s3 as s3,
+    aws_ssm as ssm,
+    aws_ecs as ecs,
+)
+from constructs import Construct
+from settings.settings import ProjectSettings
+
+
+class SagemakerStack(cdk.Stack):
+    def __init__(
+        self, scope: Construct, id: str, config: ProjectSettings, cluster: ecs.Cluster, **kwargs
+    ) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self.prefix = config.env_id
+
+        # Create IAM role for SageMaker Users
+        self.sm_execution_role = self.create_execution_role()
+
+        # Create S3 bucket for SageMaker code sources
+        self.sm_sources_bucket = self.create_sm_sources_bucket()
+
+        ssm.StringParameter(
+            self,
+            f"{self.prefix}SourcesBucketName",
+            string_value=self.sm_sources_bucket.bucket_name,
+            parameter_name=f"/{self.prefix}/SourcesBucketName",
+            description="SageMaker Sources Bucket Name",
+        )
+
+        # Grant read access to SageMaker execution role
+        self.sm_sources_bucket.grant_read(self.sm_execution_role)
+
+        # Create S3 bucket for SageMaker data
+        self.sm_data_bucket = self.create_data_bucket()
+
+        # Grant read/write access to SageMaker execution role
+        self.sm_data_bucket.grant_read_write(self.sm_execution_role)
+
+        # Fetch VPC information
+        self.vpc = cluster.vpc
+        public_subnet_ids = [public_subnet.subnet_id for public_subnet in self.vpc.public_subnets]
+
+        # Create SageMaker Studio domain
+        self.domain = sm.CfnDomain(
+            self,
+            f"{self.prefix}SagemakerDomain",
+            auth_mode="IAM",
+            domain_name=f"{self.prefix}-SG-Project",
+            default_user_settings=sm.CfnDomain.UserSettingsProperty(
+                execution_role=self.sm_execution_role.role_arn
+            ),
+            app_network_access_type="PublicInternetOnly",
+            vpc_id=self.vpc.vpc_id,
+            subnet_ids=public_subnet_ids,
+            tags=[cdk.CfnTag(key="project", value="example-pipelines")],
+        )
+
+        # Create SageMaker Studio default user profile
+        self.user = sm.CfnUserProfile(
+            self,
+            f"{self.prefix}SageMakerStudioUserProfile",
+            domain_id=self.domain.attr_domain_id,
+            user_profile_name="default-user",
+            user_settings=sm.CfnUserProfile.UserSettingsProperty(),
+        )
+
+    def create_execution_role(self) -> iam.Role:
+        role = iam.Role(
+            self,
+            f"{self.prefix}SagemakerExecutionRole",
+            assumed_by=iam.ServicePrincipal("sagemaker.amazonaws.com"),
+            role_name=f"{self.prefix}-sm-execution-role",
+            managed_policies=[
+                iam.ManagedPolicy.from_managed_policy_arn(
+                    self,
+                    id="SagemakerFullAccess",
+                    managed_policy_arn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+                ),
+            ],
+        )
+        ssm.StringParameter(
+            self,
+            f"{self.prefix}SagemakerExecutionRoleArn",
+            string_value=role.role_arn,
+            parameter_name=f"/{self.prefix}/SagemakerExecutionRoleArn",
+            description="SageMaker Execution Role ARN",
+        )
+
+        return role
+
+    def create_sm_sources_bucket(self) -> s3.Bucket:
+        return s3.Bucket(
+            self,
+            id=f"{self.prefix}SourcesBucket",
+            bucket_name=f"{self.prefix}-sm-sources",
+            lifecycle_rules=[],
+            versioned=False,
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+            auto_delete_objects=True,
+            # Access
+            access_control=s3.BucketAccessControl.PRIVATE,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            public_read_access=False,
+            object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
+            enforce_ssl=True,
+            # Encryption
+            encryption=s3.BucketEncryption.S3_MANAGED,
+        )
+
+    def create_data_bucket(self):
+        return s3.Bucket(
+            self,
+            id=f"{self.prefix}DataBucket",
+            bucket_name=f"{self.prefix}-sm-data",
+            lifecycle_rules=[],
+            versioned=False,
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+            auto_delete_objects=True,
+            # Access
+            access_control=s3.BucketAccessControl.PRIVATE,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            public_read_access=False,
+            object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
+            enforce_ssl=True,
+            # Encryption
+            encryption=s3.BucketEncryption.S3_MANAGED,
+        )

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -56,6 +56,24 @@ class SagemakerStack(cdk.Stack):
         # Grant read/write access to SageMaker execution role
         self.sm_data_bucket.grant_read_write(self.sm_execution_role)
 
+        self.mermaid_image_processing_bucket = s3.Bucket.from_bucket_arn(
+            self,
+            f"{self.prefix}ImageProcessingBucket",
+            bucket_arn="arn:aws:s3:::datamermaid-image-processing",
+        )
+        # Grant read/write access to SageMaker execution role
+        self.mermaid_image_processing_bucket.grant_read(self.sm_execution_role)
+
+        self.coral_reef_training_bucket = s3.Bucket.from_bucket_arn(
+            self,
+            f"{self.prefix}CoralReefTrainingBucket",
+            bucket_arn="arn:aws:s3:::datamermaid-coral-reef-training",
+        )
+        # Grant read/write access to SageMaker execution role
+        self.coral_reef_training_bucket.grant_read(
+            identity=self.sm_execution_role, objects_key_pattern="mermaid/*"
+        )
+
         # Fetch VPC information
         self.vpc = cluster.vpc
         private_subnet_ids = [

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -178,7 +178,6 @@ class SagemakerStack(cdk.Stack):
             bucket_name=bucket_name,
             versioned=False,
             removal_policy=cdk.RemovalPolicy.DESTROY,
-            auto_delete_objects=True,
             # Access
             access_control=s3.BucketAccessControl.PRIVATE,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -61,7 +61,7 @@ class SagemakerStack(cdk.Stack):
             f"{self.prefix}ImageProcessingBucket",
             bucket_arn="arn:aws:s3:::mermaid-image-processing",
         )
-        # Grant read/write access to SageMaker execution role
+        # Grant read access to SageMaker execution role
         self.mermaid_image_processing_bucket.grant_read(self.sm_execution_role)
 
         # Fetch VPC information

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -52,7 +52,7 @@ class SagemakerStack(cdk.Stack):
 
         # Fetch VPC information
         self.vpc = cluster.vpc
-        public_subnet_ids = [
+        private_subnet_ids = [
             private_subnet.subnet_id for private_subnet in self.vpc.private_subnets
         ]
 
@@ -67,7 +67,7 @@ class SagemakerStack(cdk.Stack):
             ),
             app_network_access_type="VpcOnly",
             vpc_id=self.vpc.vpc_id,
-            subnet_ids=public_subnet_ids,
+            subnet_ids=private_subnet_ids,
             domain_settings=sm.CfnDomain.DomainSettingsProperty(
                 docker_settings=sm.CfnDomain.DockerSettingsProperty(
                     enable_docker_access="ENABLED",

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -4,7 +4,6 @@ from aws_cdk import (
     aws_iam as iam,
     aws_s3 as s3,
     aws_sagemaker as sm,
-    aws_ssm as ssm,
     CfnOutput,
 )
 from constructs import Construct
@@ -76,14 +75,6 @@ class SagemakerStack(cdk.Stack):
             ),
         )
 
-        # ssm.StringParameter(
-        #     self,
-        #     f"{self.prefix}SagemakerDomainUrl",
-        #     string_value=self.domain.attr_url,
-        #     parameter_name=f"/{self.prefix}/SagemakerDomainUrl",
-        #     description="SageMaker Domain URL",
-        # )
-
         CfnOutput(
             self,
             f"{self.prefix}SagemakerDomainUrl",
@@ -106,13 +97,7 @@ class SagemakerStack(cdk.Stack):
                 ),
             ],
         )
-        # ssm.StringParameter(
-        #     self,
-        #     f"{self.prefix}SagemakerExecutionRoleArn",
-        #     string_value=role.role_arn,
-        #     parameter_name=f"/{self.prefix}/SagemakerExecutionRoleArn",
-        #     description="SageMaker Execution Role ARN",
-        # )
+
         CfnOutput(
             self,
             f"{self.prefix}SagemakerExecutionRoleArn",

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -59,20 +59,10 @@ class SagemakerStack(cdk.Stack):
         self.mermaid_image_processing_bucket = s3.Bucket.from_bucket_arn(
             self,
             f"{self.prefix}ImageProcessingBucket",
-            bucket_arn="arn:aws:s3:::datamermaid-image-processing",
+            bucket_arn="arn:aws:s3:::mermaid-image-processing",
         )
         # Grant read/write access to SageMaker execution role
         self.mermaid_image_processing_bucket.grant_read(self.sm_execution_role)
-
-        self.coral_reef_training_bucket = s3.Bucket.from_bucket_arn(
-            self,
-            f"{self.prefix}CoralReefTrainingBucket",
-            bucket_arn="arn:aws:s3:::datamermaid-coral-reef-training",
-        )
-        # Grant read/write access to SageMaker execution role
-        self.coral_reef_training_bucket.grant_read(
-            identity=self.sm_execution_role, objects_key_pattern="mermaid/*"
-        )
 
         # Fetch VPC information
         self.vpc = cluster.vpc
@@ -110,6 +100,7 @@ class SagemakerStack(cdk.Stack):
                 security_group_ids=[
                     self.security_group.security_group_id,
                 ],
+
             ),
             default_space_settings=sm.CfnDomain.DefaultSpaceSettingsProperty(
                 execution_role=self.sm_execution_role.role_arn,


### PR DESCRIPTION
Adopted from:
1. https://www.luminis.eu/blog/deploying-sagemaker-pipelines-using-aws-cdk/
2. https://github.com/egordm/blog-deploying-sagemaker-pipelines/blob/master/infrastructure_project/infrastructure_project/sagemaker_stack.py
3. https://github.com/aws-samples/cloudformation-studio-domain/blob/main/sagemaker-domain-with-vpc.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added infrastructure support for SageMaker in the development environment, including SageMaker Studio setup, dedicated encrypted S3 buckets for code and data storage, and necessary IAM roles with appropriate access.
  - Integrated SageMaker resources with existing networking, environment settings, and tagging for seamless management and secure VPC-only access.
  - Enhanced network configuration with new security groups and private VPC endpoints for SageMaker services to enable secure, private connectivity within the VPC.
  - Updated documentation with a new "Sagemaker AI" section detailing deployment URLs, user and group management, bucket access, and related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->