### PR TITLE
Fix access issue with training bucket

### DIFF
--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -372,3 +372,13 @@ class ApiStack(Stack):
         data_bucket.grant_read_write(service.task_definition.task_role)
         data_bucket.grant_read_write(summary_cache_service.task_definition.task_role)
         data_bucket.grant_delete(summary_cache_service.task_definition.task_role)
+
+        # Prod bucket needs to read from coral-reef-training bucket.
+        # There is some issue with assumed-role reading from public bucket,
+        # addinf read permission to the task role seems to fix it.
+        coral_reef_training_bucket = s3.Bucket.from_bucket_name(
+            self,
+            "CoralReefBucket",
+            bucket_name="coral-reef-training",
+        )
+        coral_reef_training_bucket.grant_read(service.task_definition.task_role)

--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -372,13 +372,12 @@ class ApiStack(Stack):
         data_bucket.grant_read_write(service.task_definition.task_role)
         data_bucket.grant_read_write(summary_cache_service.task_definition.task_role)
         data_bucket.grant_delete(summary_cache_service.task_definition.task_role)
-
         # Prod bucket needs to read from coral-reef-training bucket.
         # There is some issue with assumed-role reading from public bucket,
-        # addinf read permission to the task role seems to fix it.
+        # adding read permission to the task role seems to fix it.
         coral_reef_training_bucket = s3.Bucket.from_bucket_name(
             self,
             "CoralReefBucket",
-            bucket_name="coral-reef-training",
+            bucket_name=config.api.ic_bucket_name,
         )
         coral_reef_training_bucket.grant_read(service.task_definition.task_role)

--- a/src/api/utils/classification.py
+++ b/src/api/utils/classification.py
@@ -274,8 +274,6 @@ def _get_image_location(image: Image):
     if settings.ENVIRONMENT == "local":
         return DataLocation("filesystem", image.image.path)
     else:
-        print(f"{settings.IMAGE_S3_PATH}{image.image.name}")
-        print(settings.IMAGE_PROCESSING_BUCKET)
         return DataLocation(
             storage_type="s3",
             key=f"{settings.IMAGE_S3_PATH}{image.image.name}",

--- a/src/api/utils/s3.py
+++ b/src/api/utils/s3.py
@@ -122,10 +122,6 @@ def download_directory(
     if aws_secret_access_key is None:
         aws_secret_access_key = settings.AWS_SECRET_ACCESS_KEY
 
-    print(bucket)
-    print(s3_directory)
-    print(aws_access_key_id)
-    print(aws_secret_access_key)
     client = get_client(
         aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key
     )


### PR DESCRIPTION
Adds permissions to task role for accessing coral-reef-training bucket. This was blocking S3 acces for reasons that are still unknown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated permissions to allow the API service to read from the "coral-reef-training" S3 bucket.
  - Removed unnecessary print statements from the S3 download utility and image location determination for cleaner logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->