### PR TITLE
Add read access to coral reef bucket for workers.

### DIFF
--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -381,3 +381,5 @@ class ApiStack(Stack):
             bucket_name=config.api.ic_bucket_name,
         )
         coral_reef_training_bucket.grant_read(service.task_definition.task_role)
+        coral_reef_training_bucket.grant_read(image_worker.task_definition.task_role)
+        coral_reef_training_bucket.grant_read(worker.task_definition.task_role)


### PR DESCRIPTION
As per title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded read access to the coral reef training bucket for additional background worker services, allowing them to retrieve data from the bucket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->