### PR TITLE
M1514-az-rebalance

### DIFF
--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -235,7 +235,7 @@ class ApiStack(Stack):
             security_groups=[container_security_group],
             enable_execute_command=True,
             capacity_provider_strategies=cluster.default_capacity_provider_strategy,
-            # circuit_breaker=ecs.DeploymentCircuitBreaker(enable=True, rollback=True),
+            availability_zone_rebalancing=ecs.AvailabilityZoneRebalancing.ENABLED,
         )
 
         # --- API Service ---
@@ -264,7 +264,7 @@ class ApiStack(Stack):
             desired_count=config.api.container_count,
             enable_execute_command=True,
             capacity_provider_strategies=cluster.default_capacity_provider_strategy,
-            # circuit_breaker=ecs.DeploymentCircuitBreaker(enable=True, rollback=True),
+            availability_zone_rebalancing=ecs.AvailabilityZoneRebalancing.ENABLED,
         )
 
         # Grant Secret read to API container & backup task

--- a/iac/stacks/constructs/worker.py
+++ b/iac/stacks/constructs/worker.py
@@ -58,7 +58,6 @@ class QueueWorker(Construct):
                 appscaling.ScalingInterval(lower=100, change=+1),
             ],
             capacity_provider_strategies=cluster.default_capacity_provider_strategy,
-            # circuit_breaker=ecs.DeploymentCircuitBreaker(enable=True, rollback=True),
         )
         # Allow workers to send messages.
         job_queue.queue.grant(


### PR DESCRIPTION
Enable AZ rebalancing on services that require HA.

closes M1514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration to enable availability zone rebalancing for certain services.
  - Removed outdated commented configuration lines related to deployment circuit breakers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->