### PR TITLE
cdk acknowledge

### DIFF
--- a/iac/cdk.context.json
+++ b/iac/cdk.context.json
@@ -22,7 +22,8 @@
     "Name": "api2.datamermaid.org."
   },
   "acknowledged-issue-numbers": [
-    32775
+    32775,
+    34892
   ],
   "endpoint-service-availability-zones:account=554812291621:region=us-east-1:serviceName=com.amazonaws.us-east-1.sagemaker.api": [
     "us-east-1a",


### PR DESCRIPTION
```
❯ cdk acknowledge 34892

NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)

34892	CDK CLI will collect telemetry data on command usage starting at version 2.1100.0 (unless opted out)

	Overview: We do not collect customer content and we anonymize the
	          telemetry we do collect. See the attached issue for more
	          information on what data is collected, why, and how to
	          opt-out. Telemetry will NOT be collected for any CDK CLI
	          version prior to version 2.1100.0 - regardless of
	          opt-in/out.

	Affected versions: cli: ^2.0.0

	More information at: https://github.com/aws/aws-cdk/issues/34892


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 34892".
```