### PR TITLE
Add sagemaker experiements and mlflow

### DIFF
--- a/iac/cdk.context.json
+++ b/iac/cdk.context.json
@@ -56,5 +56,10 @@
     "us-east-1d",
     "us-east-1e",
     "us-east-1f"
+  ],
+  "endpoint-service-availability-zones:account=554812291621:region=us-east-1:serviceName=aws.sagemaker.us-east-1.experiments": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1d"
   ]
 }

--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -295,6 +295,7 @@ class CommonStack(Stack):
             "SAGEMAKER_NOTEBOOK",
             "SAGEMAKER_RUNTIME",
             "SAGEMAKER_STUDIO",
+            "SAGEMAKER_EXPERIMENTS",
         ]:
             self.vpc.add_interface_endpoint(
                 f"{service_name}VpcEndpoint",

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -53,13 +53,11 @@ class SagemakerStack(cdk.Stack):
             export_name=f"{self.prefix}-SourcesBucketName",
         )
 
-        # Grant read access to SageMaker execution role
         self.sm_sources_bucket.grant_read(self.sm_execution_role)
 
         # Create S3 bucket for SageMaker data
         self.sm_data_bucket = self.create_data_bucket()
 
-        # Grant read/write access to SageMaker execution role
         self.sm_data_bucket.grant_read_write(self.sm_execution_role)
 
         self.mermaid_image_processing_bucket = s3.Bucket.from_bucket_arn(
@@ -68,7 +66,6 @@ class SagemakerStack(cdk.Stack):
             bucket_arn="arn:aws:s3:::mermaid-image-processing",
         )
 
-        # Grant read access to SageMaker execution role
         self.mermaid_image_processing_bucket.grant_read(self.sm_execution_role)
 
         self.mermaid_config = s3.Bucket.from_bucket_arn(
@@ -76,7 +73,7 @@ class SagemakerStack(cdk.Stack):
             f"{self.prefix}MermaidConfigBucket",
             bucket_arn="arn:aws:s3:::mermaid-config",
         )
-        # Grant read access to SageMaker execution role
+
         self.mermaid_config.grant_read_write(self.sm_execution_role)
 
         self.coralnet_public_sources = s3.Bucket.from_bucket_arn(
@@ -84,7 +81,7 @@ class SagemakerStack(cdk.Stack):
             f"{self.prefix}CoralnetPublicSourcesBucket",
             bucket_arn="arn:aws:s3:::2310-coralnet-public-sources",
         )
-        # Grant read access to SageMaker execution role
+
         self.coralnet_public_sources.grant_read(self.sm_execution_role)
 
         self.pyspacer_test = s3.Bucket.from_bucket_arn(
@@ -92,7 +89,7 @@ class SagemakerStack(cdk.Stack):
             f"{self.prefix}PyspacerTestBucket",
             bucket_arn="arn:aws:s3:::pyspacer-test",
         )
-        # Grant read access to SageMaker execution role
+
         self.pyspacer_test.grant_read(self.sm_execution_role)
 
         self.security_group = ec2.SecurityGroup(
@@ -174,14 +171,16 @@ class SagemakerStack(cdk.Stack):
         )
 
         role.attach_inline_policy(
-            iam.Policy(self, "MlflowRolePolicy",
+            iam.Policy(
+                self,
+                "MlflowRolePolicy",
                 statements=[
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,
                         actions=["sagemaker-mlflow:*"],
                         resources=["*"],
                     )
-                ]
+                ],
             )
         )
 

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -67,8 +67,33 @@ class SagemakerStack(cdk.Stack):
             f"{self.prefix}ImageProcessingBucket",
             bucket_arn="arn:aws:s3:::mermaid-image-processing",
         )
+
         # Grant read access to SageMaker execution role
         self.mermaid_image_processing_bucket.grant_read(self.sm_execution_role)
+
+        self.mermaid_config = s3.Bucket.from_bucket_arn(
+            self,
+            f"{self.prefix}MermaidConfigBucket",
+            bucket_arn="arn:aws:s3:::mermaid-config",
+        )
+        # Grant read access to SageMaker execution role
+        self.mermaid_config.grant_read_write(self.sm_execution_role)
+
+        self.coralnet_public_sources = s3.Bucket.from_bucket_arn(
+            self,
+            f"{self.prefix}CoralnetPublicSourcesBucket",
+            bucket_arn="arn:aws:s3:::2310-coralnet-public-sources",
+        )
+        # Grant read access to SageMaker execution role
+        self.coralnet_public_sources.grant_read(self.sm_execution_role)
+
+        self.pyspacer_test = s3.Bucket.from_bucket_arn(
+            self,
+            f"{self.prefix}PyspacerTestBucket",
+            bucket_arn="arn:aws:s3:::pyspacer-test",
+        )
+        # Grant read access to SageMaker execution role
+        self.pyspacer_test.grant_read(self.sm_execution_role)
 
         self.security_group = ec2.SecurityGroup(
             self,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for provisioning a SageMaker Experiments VPC endpoint.
  * SageMaker Studio domain now deploys within private subnets for improved security.

* **Improvements**
  * SageMaker execution role now includes permissions for all sagemaker-mlflow actions.
  * Enhanced configuration of security groups and subnet assignments for SageMaker Studio.

* **Refactor**
  * Improved code structure for VPC and subnet retrieval and import organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->