### PR TITLE
Only use sentry in prod environment

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -288,12 +288,12 @@ MC_API_KEY = os.environ.get("MC_API_KEY")
 MC_USER = os.environ.get("MC_USER")
 MC_LIST_ID = os.environ.get("MC_LIST_ID")
 
-
-sentry_sdk.init(
-    dsn=os.environ.get("SENTRY_DSN"),
-    traces_sample_rate=1.0,
-    environment=ENVIRONMENT,
-)
+if ENVIRONMENT == "prod":
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        traces_sample_rate=1.0,
+        environment=ENVIRONMENT,
+    )
 
 
 # ************************


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Adjusted error reporting so it only initializes in production environments. This confines monitoring to live usage and avoids telemetry in non-production setups.
  * No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->