### PR TITLE
[M1855] move to PIL EXIF handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ src/media/*
 src/_classifiers/*
 mynotes.md
 generate_token.py
+.reviews/
+.claude/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ django-taggit==6.1.0
 dotty-dict==1.3.1
 drf-nested-routers==0.94.2
 drf-recaptcha==4.0.2
-exif==1.6.1
 gunicorn==22.0.0
 mailchimp3==3.0.21
 natsort==8.4.0

--- a/src/api/migrations/0104_backfill_exif_keys.py
+++ b/src/api/migrations/0104_backfill_exif_keys.py
@@ -1,21 +1,15 @@
 """
-Migrate stored EXIF data from the old exif-library snake_case key format to
-PIL CamelCase tag names.
+Data migration: rename EXIF keys stored by the old `exif` library (snake_case)
+to PIL CamelCase tag names.
 
-Background: before M1855, store_exif used the `exif` Python library whose
-attribute names differed from PIL's.  For example, PIL uses "DateTimeOriginal"
-while the exif library used "datetime_original".  The 3,000+ JPEG images
-uploaded before the fix have old-format keys stored in class_image.data["exif"].
-This command renames those keys in-place; no S3 access is required.
-
-Usage:
-    python manage.py backfill_exif_keys [--dry-run] [--batch-size N]
+Before M1855, store_exif used the `exif` Python library whose attribute names
+differed from PIL's — e.g. PIL uses "DateTimeOriginal" while the exif library
+used "datetime_original".  Images uploaded before M1855 have old-format keys
+in class_image.data["exif"].  This migration renames those keys in-place; no
+S3 access is required.
 """
 
-from django.core.management.base import BaseCommand
-from django.db import transaction
-
-from api.models import Image
+from django.db import migrations, transaction
 
 # Maps every exif-library attribute name that has appeared in production data
 # to its PIL.ExifTags equivalent.  Internal pointer fields (prefixed with _)
@@ -57,18 +51,18 @@ _EXIF_LIB_TO_PIL = {
     "x_resolution": "XResolution",
     "y_resolution": "YResolution",
     "resolution_unit": "ResolutionUnit",
-    "y_and_c_positioning": "YCbCrPositioning",  # PIL name differs
-    "pixel_x_dimension": "ExifImageWidth",  # PIL name differs
-    "pixel_y_dimension": "ExifImageHeight",  # PIL name differs
+    "y_and_c_positioning": "YCbCrPositioning",
+    "pixel_x_dimension": "ExifImageWidth",
+    "pixel_y_dimension": "ExifImageHeight",
     "compression": "Compression",
     "compressed_bits_per_pixel": "CompressedBitsPerPixel",
-    "jpeg_interchange_format": "JpegIFOffset",  # PIL name differs
-    "jpeg_interchange_format_length": "JpegIFByteCount",  # PIL name differs
+    "jpeg_interchange_format": "JpegIFOffset",
+    "jpeg_interchange_format_length": "JpegIFByteCount",
     # ── exposure / photometry ─────────────────────────────────────────────────
     "exposure_time": "ExposureTime",
     "f_number": "FNumber",
     "exposure_program": "ExposureProgram",
-    "photographic_sensitivity": "ISOSpeedRatings",  # PIL name differs
+    "photographic_sensitivity": "ISOSpeedRatings",
     "sensitivity_type": "SensitivityType",
     "recommended_exposure_index": "RecommendedExposureIndex",
     "shutter_speed_value": "ShutterSpeedValue",
@@ -94,7 +88,7 @@ _EXIF_LIB_TO_PIL = {
     "custom_rendered": "CustomRendered",
     "exposure_index": "ExposureIndex",
     "sensing_method": "SensingMethod",
-    "subject_area": "SubjectLocation",  # PIL name differs
+    "subject_area": "SubjectLocation",
     # ── colour / rendering ────────────────────────────────────────────────────
     "color_space": "ColorSpace",
     "exif_version": "ExifVersion",
@@ -119,7 +113,7 @@ _EXIF_LIB_TO_PIL = {
     "gps_img_direction": "GPSImgDirection",
     "gps_dest_bearing_ref": "GPSDestBearingRef",
     "gps_dest_bearing": "GPSDestBearing",
-    "gps_horizontal_positioning_error": "GPSHPositioningError",  # PIL name shorter
+    "gps_horizontal_positioning_error": "GPSHPositioningError",
     "gps_status": "GPSStatus",
 }
 
@@ -140,7 +134,7 @@ def _is_old_format(exif_dict: dict) -> bool:
     )
 
 
-def _migrate_exif_dict(exif_dict: dict) -> tuple[dict, list[str]]:
+def _migrate_exif_dict(exif_dict: dict) -> tuple:
     """Return (migrated_dict, unknown_keys) from exif-lib to PIL CamelCase.
 
     Explicitly dropped keys (internal pointer fields mapped to None) are silently
@@ -156,86 +150,48 @@ def _migrate_exif_dict(exif_dict: dict) -> tuple[dict, list[str]]:
             continue
         new_key = _EXIF_LIB_TO_PIL[old_key]
         if new_key is None:
-            # Explicitly dropped internal pointer field — discard silently
             continue
         result[new_key] = value
     return result, unknown
 
 
-class Command(BaseCommand):
-    help = (
-        "Rename EXIF keys in class_image.data from the old exif-library snake_case "
-        "format (e.g. 'datetime_original') to PIL CamelCase (e.g. 'DateTimeOriginal'). "
-        "Affects images uploaded before M1855.  No S3 access required."
-    )
+def backfill_exif_keys(apps, schema_editor):
+    Image = apps.get_model("api", "Image")
+    batch_size = 200
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help="Report what would change without writing to the database.",
-        )
-        parser.add_argument(
-            "--batch-size",
-            type=int,
-            default=200,
-            help="Number of images to update per transaction (default: 200).",
-        )
+    qs = Image.objects.filter(data__has_key="exif").only("id", "data")
+    batch = []
 
-    def handle(self, *args, **options):
-        dry_run = options["dry_run"]
-        batch_size = options["batch_size"]
+    for image in qs.iterator(chunk_size=batch_size):
+        exif_dict = image.data.get("exif", {})
+        if not isinstance(exif_dict, dict) or not _is_old_format(exif_dict):
+            continue
 
-        qs = Image.objects.filter(data__has_key="exif")
-        total = qs.count()
-        self.stdout.write(f"Found {total} images with stored EXIF data.")
+        new_exif, unknown_keys = _migrate_exif_dict(exif_dict)
+        if unknown_keys:
+            print(
+                f"  WARNING {image.pk}: {len(unknown_keys)} unmapped key(s): "
+                + ", ".join(repr(k) for k in unknown_keys)
+            )
 
-        updated = skipped = 0
-        batch = []
+        image.data["exif"] = new_exif
+        batch.append(image)
 
-        for image in qs.iterator():
-            exif_dict = image.data.get("exif", {})
-            if not isinstance(exif_dict, dict):
-                self.stderr.write(
-                    f"  WARNING {image.pk}: exif value is not a dict ({type(exif_dict).__name__}), skipping"
-                )
-                skipped += 1
-                continue
-            if not _is_old_format(exif_dict):
-                skipped += 1
-                continue
+        if len(batch) >= batch_size:
+            with transaction.atomic():
+                Image.objects.bulk_update(batch, ["data"])
+            batch = []
 
-            new_exif, unknown_keys = _migrate_exif_dict(exif_dict)
-            if unknown_keys:
-                self.stderr.write(
-                    f"  WARNING {image.pk}: {len(unknown_keys)} unmapped key(s): "
-                    + ", ".join(unknown_keys)
-                )
-            if dry_run:
-                self.stdout.write(
-                    f"  [dry-run] {image.pk}: would rename "
-                    f"{len(exif_dict)} → {len(new_exif)} keys"
-                )
-                updated += 1
-                continue
-
-            image.data["exif"] = new_exif
-            batch.append(image)
-            updated += 1
-
-            if len(batch) >= batch_size:
-                self._flush(batch)
-                batch = []
-
-        if batch:
-            self._flush(batch)
-
-        status = "Would update" if dry_run else "Updated"
-        self.stdout.write(
-            self.style.SUCCESS(f"{status} {updated} images; skipped {skipped} already-current.")
-        )
-
-    def _flush(self, batch):
+    if batch:
         with transaction.atomic():
             Image.objects.bulk_update(batch, ["data"])
-        self.stdout.write(f"  flushed {len(batch)} records")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0103_allow_null_collect_explore_state"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_exif_keys, migrations.RunPython.noop),
+    ]

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -1,5 +1,11 @@
+import io
+from unittest.mock import MagicMock
+
+from PIL import Image as PILImage
+
 from api.models import BenthicTransect, QuadratCollection, QuadratTransect, SampleUnit
 from api.utils import get_subclasses
+from api.utils.classification import store_exif
 
 
 def test_get_subclasses():
@@ -7,3 +13,45 @@ def test_get_subclasses():
     assert BenthicTransect in subclasses
     assert QuadratTransect in subclasses
     assert QuadratCollection in subclasses
+
+
+def _make_instance(file_bytes):
+    """Minimal Image-like object sufficient for store_exif."""
+    file_obj = io.BytesIO(file_bytes)
+    instance = MagicMock()
+    instance.image.file = file_obj
+    instance.data = None
+    return instance
+
+
+def test_store_exif_jpeg():
+    # JPEG images raised AttributeError before the fix because PIL's JpegImagePlugin
+    # defines __getattr__ that raises for unknown names, so img.read() on the PIL
+    # Image object failed. With the fix (reading from file_obj directly) it works.
+    with open("api/tests/data/test_image.jpg", "rb") as f:
+        jpeg_bytes = f.read()
+
+    instance = _make_instance(jpeg_bytes)
+    store_exif(instance)  # must not raise
+
+    assert instance.data is not None
+    assert "exif" in instance.data
+    assert len(instance.data["exif"]) > 0
+
+
+def test_store_exif_png():
+    # PNG images produce the same observable result before and after the fix:
+    # no EXIF is stored (PNGs don't carry JPEG-style EXIF data).
+    # Old code: img.read() raises AttributeError, caught by the signal's outer
+    #   except-Exception handler — upload still succeeds, no EXIF stored.
+    # New code: file_obj.read() returns bytes; ExifImage raises UnpackError on
+    #   non-EXIF bytes, caught internally — upload succeeds, no EXIF stored.
+    buf = io.BytesIO()
+    PILImage.new("RGB", (10, 10)).save(buf, format="PNG")
+    png_bytes = buf.getvalue()
+
+    instance = _make_instance(png_bytes)
+    store_exif(instance)  # must not raise
+
+    # PNG has no EXIF — store_exif returns early without setting instance.data
+    assert instance.data is None

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -142,6 +142,14 @@ def test_extract_datetime_stamp_no_offset():
     assert extract_datetime_stamp(exif_ifd, {}) is None
 
 
+def test_extract_datetime_stamp_offset_time_original():
+    # Cameras that write OffsetTimeOriginal (36881) but not OffsetTime (36880)
+    # must still produce a correct UTC timestamp.
+    exif_ifd = {36867: "2017:09:06 10:17:33", 36881: "+13:00"}  # OffsetTimeOriginal only
+    result = extract_datetime_stamp(exif_ifd, {})
+    assert result == datetime.datetime(2017, 9, 5, 21, 17, 33, tzinfo=datetime.timezone.utc)
+
+
 def test_extract_datetime_stamp_malformed_gps_falls_through():
     # Malformed GPS timestamp triggers except and falls through to EXIF fallback.
     gps_ifd = {29: "not-a-date", 7: ("bad", "data", "here")}

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -1,11 +1,15 @@
+import datetime
 import io
+import struct
+import zlib
+from fractions import Fraction
 from unittest.mock import MagicMock
 
 from PIL import Image as PILImage
 
 from api.models import BenthicTransect, QuadratCollection, QuadratTransect, SampleUnit
 from api.utils import get_subclasses
-from api.utils.classification import store_exif
+from api.utils.classification import extract_datetime_stamp, extract_location, store_exif
 
 
 def test_get_subclasses():
@@ -24,34 +28,101 @@ def _make_instance(file_bytes):
     return instance
 
 
+def _make_png_with_exif(exif_bytes):
+    """Build a minimal PNG containing an eXIf chunk from the given raw EXIF bytes."""
+    base = io.BytesIO()
+    PILImage.new("RGB", (10, 10)).save(base, format="PNG")
+    base_png = base.getvalue()
+
+    def png_chunk(chunk_type, data):
+        body = chunk_type + data
+        return (
+            struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+        )
+
+    iend_pos = base_png.rfind(b"IEND")
+    return base_png[: iend_pos - 4] + png_chunk(b"eXIf", exif_bytes) + base_png[iend_pos - 4 :]
+
+
 def test_store_exif_jpeg():
-    # JPEG images raised AttributeError before the fix because PIL's JpegImagePlugin
-    # defines __getattr__ that raises for unknown names, so img.read() on the PIL
-    # Image object failed. With the fix (reading from file_obj directly) it works.
+    # EXIF is extracted from a JPEG and stored with PIL CamelCase tag names.
     with open("api/tests/data/test_image.jpg", "rb") as f:
         jpeg_bytes = f.read()
 
     instance = _make_instance(jpeg_bytes)
-    store_exif(instance)  # must not raise
+    store_exif(instance)
 
     assert instance.data is not None
     assert "exif" in instance.data
-    assert len(instance.data["exif"]) > 0
+    assert "DateTimeOriginal" in instance.data["exif"]
+    assert instance.data["exif"]["Make"].strip() == "OLYMPUS CORPORATION"
 
 
-def test_store_exif_png():
-    # PNG images produce the same observable result before and after the fix:
-    # no EXIF is stored (PNGs don't carry JPEG-style EXIF data).
-    # Old code: img.read() raises AttributeError, caught by the signal's outer
-    #   except-Exception handler — upload still succeeds, no EXIF stored.
-    # New code: file_obj.read() returns bytes; ExifImage raises UnpackError on
-    #   non-EXIF bytes, caught internally — upload succeeds, no EXIF stored.
+def test_store_exif_png_no_exif():
+    # Plain PNG (no eXIf chunk): store_exif returns early, nothing stored.
     buf = io.BytesIO()
     PILImage.new("RGB", (10, 10)).save(buf, format="PNG")
-    png_bytes = buf.getvalue()
 
-    instance = _make_instance(png_bytes)
-    store_exif(instance)  # must not raise
+    instance = _make_instance(buf.getvalue())
+    store_exif(instance)
 
-    # PNG has no EXIF — store_exif returns early without setting instance.data
     assert instance.data is None
+
+
+def test_store_exif_png_with_exif_chunk():
+    # PNG with an eXIf chunk: EXIF is extracted, which was impossible with the
+    # old exif library since it only understood JPEG byte streams.
+    with open("api/tests/data/test_image.jpg", "rb") as f:
+        jpeg_bytes = f.read()
+    exif_bytes = PILImage.open(io.BytesIO(jpeg_bytes)).info.get("exif", b"")
+    assert exif_bytes, "test JPEG must carry EXIF data for this fixture to be valid"
+
+    instance = _make_instance(_make_png_with_exif(exif_bytes))
+    store_exif(instance)
+
+    assert instance.data is not None
+    assert "exif" in instance.data
+    assert "DateTimeOriginal" in instance.data["exif"]
+
+
+def test_extract_datetime_stamp_gps_priority():
+    # GPS date+time (UTC) takes priority over EXIF datetime+offset.
+    gps_ifd = {29: "2024:04:06", 7: (10, 30, 0)}  # datestamp, timestamp
+    exif_ifd = {36867: "2024:04:06 23:30:00", 36880: "+13:00"}
+
+    result = extract_datetime_stamp(exif_ifd, gps_ifd)
+    assert result == datetime.datetime(2024, 4, 6, 10, 30, 0, tzinfo=datetime.timezone.utc)
+
+
+def test_extract_datetime_stamp_offset_fallback():
+    # Without GPS time, falls back to EXIF datetime + UTC offset string.
+    exif_ifd = {36867: "2017:09:06 10:17:33", 36880: "+13:00"}
+    gps_ifd = {}
+
+    result = extract_datetime_stamp(exif_ifd, gps_ifd)
+    expected = datetime.datetime(2017, 9, 5, 21, 17, 33, tzinfo=datetime.timezone.utc)
+    assert result == expected
+
+
+def test_extract_location():
+    # Fraction has .numerator so satisfies the IFDRational duck-type check.
+    # 36°0'0"N, 139°41'0"E → (36.0, 139.6833...)
+    lat = (Fraction(36), Fraction(0), Fraction(0))
+    lon = (Fraction(139), Fraction(41), Fraction(0))
+    gps_ifd = {1: "N", 2: lat, 3: "E", 4: lon}
+
+    point = extract_location(gps_ifd)
+    assert point is not None
+    assert abs(point.y - 36.0) < 0.0001  # latitude
+    assert abs(point.x - 139.6833) < 0.001  # longitude
+
+
+def test_store_exif_tiff():
+    # TIFF images did not work with the old exif library at all; PIL handles them.
+    # A plain synthetic TIFF has no photographic EXIF sub-IFD so getexif() returns
+    # only basic TIFF structural tags — store_exif stores those and doesn't raise.
+    buf = io.BytesIO()
+    PILImage.new("RGB", (10, 10)).save(buf, format="TIFF")
+
+    instance = _make_instance(buf.getvalue())
+    store_exif(instance)  # must not raise

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -74,7 +74,8 @@ def test_store_exif_png_with_exif_chunk():
     # old exif library since it only understood JPEG byte streams.
     with open("api/tests/data/test_image.jpg", "rb") as f:
         jpeg_bytes = f.read()
-    exif_bytes = PILImage.open(io.BytesIO(jpeg_bytes)).info.get("exif", b"")
+    with PILImage.open(io.BytesIO(jpeg_bytes)) as img:
+        exif_bytes = img.info.get("exif", b"")
     assert exif_bytes, "test JPEG must carry EXIF data for this fixture to be valid"
 
     instance = _make_instance(_make_png_with_exif(exif_bytes))
@@ -126,3 +127,4 @@ def test_store_exif_tiff():
 
     instance = _make_instance(buf.getvalue())
     store_exif(instance)  # must not raise
+    assert instance.data is not None  # plain TIFF has structural tags stored

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -1,15 +1,24 @@
 import datetime
 import io
+import pathlib
 import struct
 import zlib
 from fractions import Fraction
 from unittest.mock import MagicMock
 
+import pytest
 from PIL import Image as PILImage
 
 from api.models import BenthicTransect, QuadratCollection, QuadratTransect, SampleUnit
 from api.utils import get_subclasses
-from api.utils.classification import extract_datetime_stamp, extract_location, store_exif
+from api.utils.classification import (
+    _normalize_exif_value,
+    extract_datetime_stamp,
+    extract_location,
+    store_exif,
+)
+
+_DATA_DIR = pathlib.Path(__file__).resolve().parent / "data"
 
 
 def test_get_subclasses():
@@ -46,8 +55,7 @@ def _make_png_with_exif(exif_bytes):
 
 def test_store_exif_jpeg():
     # EXIF is extracted from a JPEG and stored with PIL CamelCase tag names.
-    with open("api/tests/data/test_image.jpg", "rb") as f:
-        jpeg_bytes = f.read()
+    jpeg_bytes = (_DATA_DIR / "test_image.jpg").read_bytes()
 
     instance = _make_instance(jpeg_bytes)
     store_exif(instance)
@@ -56,6 +64,20 @@ def test_store_exif_jpeg():
     assert "exif" in instance.data
     assert "DateTimeOriginal" in instance.data["exif"]
     assert instance.data["exif"]["Make"].strip() == "OLYMPUS CORPORATION"
+
+
+def test_store_exif_jpeg_sets_location_and_timestamp():
+    # Verify store_exif writes location and photo_timestamp, not just data["exif"].
+    # The fixture JPEG has DateTimeOriginal + OffsetTime but no GPS lat/lon, so
+    # photo_timestamp is populated and location is None.
+    jpeg_bytes = (_DATA_DIR / "test_image.jpg").read_bytes()
+    instance = _make_instance(jpeg_bytes)
+    instance.location = None
+    instance.photo_timestamp = None
+    store_exif(instance)
+
+    assert instance.photo_timestamp is not None
+    assert instance.location is None
 
 
 def test_store_exif_png_no_exif():
@@ -72,18 +94,22 @@ def test_store_exif_png_no_exif():
 def test_store_exif_png_with_exif_chunk():
     # PNG with an eXIf chunk: EXIF is extracted, which was impossible with the
     # old exif library since it only understood JPEG byte streams.
-    with open("api/tests/data/test_image.jpg", "rb") as f:
-        jpeg_bytes = f.read()
+    jpeg_bytes = (_DATA_DIR / "test_image.jpg").read_bytes()
     with PILImage.open(io.BytesIO(jpeg_bytes)) as img:
         exif_bytes = img.info.get("exif", b"")
     assert exif_bytes, "test JPEG must carry EXIF data for this fixture to be valid"
 
     instance = _make_instance(_make_png_with_exif(exif_bytes))
+    instance.location = None
+    instance.photo_timestamp = None
     store_exif(instance)
 
     assert instance.data is not None
     assert "exif" in instance.data
     assert "DateTimeOriginal" in instance.data["exif"]
+    # Same fixture EXIF bytes as test_store_exif_jpeg: timestamp set, no GPS lat/lon.
+    assert instance.photo_timestamp is not None
+    assert instance.location is None
 
 
 def test_extract_datetime_stamp_gps_priority():
@@ -105,6 +131,26 @@ def test_extract_datetime_stamp_offset_fallback():
     assert result == expected
 
 
+def test_extract_datetime_stamp_empty_ifds():
+    # Both IFDs empty → None.
+    assert extract_datetime_stamp({}, {}) is None
+
+
+def test_extract_datetime_stamp_no_offset():
+    # date_time_str present but offset_str missing → None.
+    exif_ifd = {36867: "2017:09:06 10:17:33"}  # no OffsetTime key
+    assert extract_datetime_stamp(exif_ifd, {}) is None
+
+
+def test_extract_datetime_stamp_malformed_gps_falls_through():
+    # Malformed GPS timestamp triggers except and falls through to EXIF fallback.
+    gps_ifd = {29: "not-a-date", 7: ("bad", "data", "here")}
+    exif_ifd = {36867: "2017:09:06 10:17:33", 36880: "+00:00"}
+
+    result = extract_datetime_stamp(exif_ifd, gps_ifd)
+    assert result == datetime.datetime(2017, 9, 6, 10, 17, 33, tzinfo=datetime.timezone.utc)
+
+
 def test_extract_location():
     # Fraction has .numerator so satisfies the IFDRational duck-type check.
     # 36°0'0"N, 139°41'0"E → (36.0, 139.6833...)
@@ -118,6 +164,27 @@ def test_extract_location():
     assert abs(point.x - 139.6833) < 0.001  # longitude
 
 
+def test_extract_location_southern_western_hemisphere():
+    # S and W references must negate the computed decimal degrees.
+    # 18°S, 147°E (Great Barrier Reef area) and then flip to W for longitude.
+    lat = (Fraction(18), Fraction(0), Fraction(0))
+    lon = (Fraction(147), Fraction(30), Fraction(0))
+    gps_ifd = {1: "S", 2: lat, 3: "W", 4: lon}
+
+    point = extract_location(gps_ifd)
+    assert point is not None
+    assert point.y < 0  # south → negative latitude
+    assert abs(point.y - (-18.0)) < 0.0001
+    assert point.x < 0  # west → negative longitude
+    assert abs(point.x - (-147.5)) < 0.0001
+
+
+def test_extract_location_missing_fields():
+    # Missing any required GPS field → None.
+    assert extract_location({}) is None
+    assert extract_location({1: "N", 2: (Fraction(1), Fraction(0), Fraction(0))}) is None
+
+
 def test_store_exif_tiff():
     # TIFF images did not work with the old exif library at all; PIL handles them.
     # A plain synthetic TIFF has no photographic EXIF sub-IFD so getexif() returns
@@ -128,3 +195,26 @@ def test_store_exif_tiff():
     instance = _make_instance(buf.getvalue())
     store_exif(instance)  # must not raise
     assert instance.data is not None  # plain TIFF has structural tags stored
+    assert isinstance(instance.data.get("exif"), dict)
+    assert len(instance.data["exif"]) > 0
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (b"\x00\xff", None),  # bytes → dropped
+        (Fraction(3, 2), 1.5),  # IFDRational-like (has .numerator) → float
+        ((Fraction(1), Fraction(2)), (1.0, 2.0)),  # tuple of rationals → tuple of floats
+        ((None, None), None),  # tuple where all elements normalize to None → None
+        ("hello\x00", "hello"),  # str → stripped null bytes
+        ("  padded  ", "padded"),  # str → stripped whitespace
+        (42, 42),  # int → pass-through (not converted to float)
+        (3.14, 3.14),  # float → pass-through
+        ({"nested": "dict"}, None),  # unexpected type → None
+    ],
+)
+def test_normalize_exif_value(value, expected):
+    result = _normalize_exif_value(value)
+    assert result == expected
+    if expected is not None:
+        assert type(result) is type(expected)  # 42 must stay int, not become 42.0

--- a/src/api/utils/classification.py
+++ b/src/api/utils/classification.py
@@ -147,14 +147,16 @@ def _normalize_exif_value(value):
     """Convert a PIL EXIF value to a JSON-serializable Python type."""
     if isinstance(value, bytes):
         return None  # skip binary blobs (MakerNote, UserComment raw bytes, etc.)
-    if hasattr(value, "numerator"):  # PIL.Image.IFDRational
+    if isinstance(value, (int, float)):
+        return value  # must come before hasattr(numerator) — Python int has .numerator
+    if hasattr(value, "numerator"):  # PIL.TiffImagePlugin.IFDRational
         return float(value)
     if isinstance(value, tuple):
         normalized = tuple(_normalize_exif_value(v) for v in value)
         return normalized if any(v is not None for v in normalized) else None
     if isinstance(value, str):
         return value.strip().replace("\u0000", "")
-    return value  # int, float
+    return None  # skip unrecognized types (nested IFDs, custom objects, etc.)
 
 
 def extract_datetime_stamp(
@@ -221,7 +223,7 @@ def save_normalized_imagefile(instance: Image):
                 if TAGS[orientation] == "Orientation":
                     break
 
-            exif = dict(image_file._getexif().items())
+            exif = dict(image_file.getexif().items())
 
             if exif[orientation] == 3:
                 image_file = image_file.rotate(180, expand=True)
@@ -252,7 +254,11 @@ def store_exif(instance: Image) -> None:
     gps_ifd = exif.get_ifd(_GPS_IFD_TAG)
     exif_ifd = exif.get_ifd(_EXIF_IFD_TAG)
 
-    # Build a flat dict of all EXIF tags using PIL string names, skipping IFD pointers
+    # Build a flat dict of all EXIF tags using PIL string names, skipping IFD pointers.
+    # We iterate three sources in order: IFD0 (top-level) → GPS sub-IFD → EXIF sub-IFD.
+    # If the same tag name appears in more than one IFD (e.g. "DateTime" can exist in
+    # both IFD0 and the EXIF sub-IFD), the later source wins.  Sub-IFD values are more
+    # specific (DateTimeOriginal vs DateTime) so this ordering is intentional.
     ifd_pointer_tags = {_GPS_IFD_TAG, _EXIF_IFD_TAG}
     exif_details = {}
 

--- a/src/api/utils/classification.py
+++ b/src/api/utils/classification.py
@@ -136,7 +136,8 @@ _GPS_DATESTAMP = 29  # "YYYY:MM:DD"
 
 # EXIF sub-IFD tag IDs (PIL.ExifTags.TAGS)
 _DATETIME_ORIGINAL = 36867  # "YYYY:MM:DD HH:MM:SS"
-_OFFSET_TIME = 36880  # "+HH:MM"
+_OFFSET_TIME = 36880  # "+HH:MM" — UTC offset for DateTime
+_OFFSET_TIME_ORIGINAL = 36881  # "+HH:MM" — UTC offset for DateTimeOriginal
 
 # Top-level IFD pointer tag IDs
 _GPS_IFD_TAG = 0x8825  # 34853
@@ -174,9 +175,11 @@ def extract_datetime_stamp(
         except (ValueError, TypeError):
             pass
 
-    # Fall back to EXIF datetime + UTC offset
+    # Fall back to EXIF datetime + UTC offset.
+    # Prefer OffsetTimeOriginal (semantically paired with DateTimeOriginal) but
+    # accept OffsetTime as a fallback for cameras that only write the general tag.
     date_time_str = exif_ifd.get(_DATETIME_ORIGINAL)  # "YYYY:MM:DD HH:MM:SS"
-    offset_str = exif_ifd.get(_OFFSET_TIME)  # "+HH:MM" or "-HH:MM"
+    offset_str = exif_ifd.get(_OFFSET_TIME_ORIGINAL) or exif_ifd.get(_OFFSET_TIME)  # "+HH:MM"
 
     if not date_time_str or offset_str is None:
         return None

--- a/src/api/utils/classification.py
+++ b/src/api/utils/classification.py
@@ -2,7 +2,6 @@ import datetime
 import hashlib
 import math
 import os
-from enum import Enum
 from io import BytesIO
 from operator import itemgetter
 from pathlib import Path
@@ -19,10 +18,8 @@ from django.db import IntegrityError, transaction
 from django.db.models import Exists, OuterRef
 from django.db.models.fields.files import ImageFieldFile
 from django.utils import timezone
-from exif import Image as ExifImage
 from PIL import Image as PILImage
-from PIL.ExifTags import TAGS
-from plum.exceptions import UnpackError
+from PIL.ExifTags import GPSTAGS, TAGS
 from spacer.extractors import EfficientNetExtractor
 from spacer.messages import ClassifyFeaturesMsg, DataLocation, ExtractFeaturesMsg
 from spacer.tasks import classify_features, extract_features
@@ -129,44 +126,84 @@ def convert_to_utc(timestamp_str: str) -> datetime:
     return local_time.astimezone(datetime.timezone.utc)
 
 
-def extract_datetime_stamp(exif_details: Dict[str, Any]) -> Optional[datetime.datetime]:
-    date_stamp = exif_details.get("gps_datestamp")  # str, 2024:04:06
-    time_stamp = exif_details.get("gps_timestamp")  # tuple
+# GPS sub-IFD tag IDs (PIL.ExifTags.GPSTAGS)
+_GPS_LATITUDE_REF = 1
+_GPS_LATITUDE = 2
+_GPS_LONGITUDE_REF = 3
+_GPS_LONGITUDE = 4
+_GPS_TIMESTAMP = 7  # (H, M, S) as rationals, UTC
+_GPS_DATESTAMP = 29  # "YYYY:MM:DD"
 
-    if date_stamp and time_stamp:
-        date_stamp = map(int, date_stamp.split(":"))
-        time_stamp = map(int, time_stamp)
-        return datetime.datetime(*date_stamp, *time_stamp, tzinfo=datetime.timezone.utc)
+# EXIF sub-IFD tag IDs (PIL.ExifTags.TAGS)
+_DATETIME_ORIGINAL = 36867  # "YYYY:MM:DD HH:MM:SS"
+_OFFSET_TIME = 36880  # "+HH:MM"
 
-    date_time_str = exif_details.get("datetime_original")
-    offset_time = exif_details.get("offset_time")
+# Top-level IFD pointer tag IDs
+_GPS_IFD_TAG = 0x8825  # 34853
+_EXIF_IFD_TAG = 0x8769  # 34665
 
-    if not date_stamp or not date_time_str or offset_time is None:
+
+def _normalize_exif_value(value):
+    """Convert a PIL EXIF value to a JSON-serializable Python type."""
+    if isinstance(value, bytes):
+        return None  # skip binary blobs (MakerNote, UserComment raw bytes, etc.)
+    if hasattr(value, "numerator"):  # PIL.Image.IFDRational
+        return float(value)
+    if isinstance(value, tuple):
+        normalized = tuple(_normalize_exif_value(v) for v in value)
+        return normalized if any(v is not None for v in normalized) else None
+    if isinstance(value, str):
+        return value.strip().replace("\u0000", "")
+    return value  # int, float
+
+
+def extract_datetime_stamp(
+    exif_ifd: Dict[int, Any], gps_ifd: Dict[int, Any]
+) -> Optional[datetime.datetime]:
+    # GPS date+time is already UTC — use it if present
+    date_stamp = gps_ifd.get(_GPS_DATESTAMP)  # "YYYY:MM:DD"
+    time_stamp = gps_ifd.get(_GPS_TIMESTAMP)  # (H, M, S) as IFDRationals
+
+    if date_stamp and time_stamp and len(time_stamp) >= 3:
+        try:
+            y, mo, d = map(int, date_stamp.split(":"))
+            h, mi, s = int(time_stamp[0]), int(time_stamp[1]), int(time_stamp[2])
+            return datetime.datetime(y, mo, d, h, mi, s, tzinfo=datetime.timezone.utc)
+        except (ValueError, TypeError):
+            pass
+
+    # Fall back to EXIF datetime + UTC offset
+    date_time_str = exif_ifd.get(_DATETIME_ORIGINAL)  # "YYYY:MM:DD HH:MM:SS"
+    offset_str = exif_ifd.get(_OFFSET_TIME)  # "+HH:MM" or "-HH:MM"
+
+    if not date_time_str or offset_str is None:
         return None
 
-    dt = datetime.datetime.strptime(date_time_str, "%Y:%m:%d %H:%M:%S")
-    offset = datetime.timedelta(hours=offset_time)
-    local_tz = datetime.timezone(offset)
-    dt_local = dt.replace(tzinfo=local_tz)
-
-    return dt_local.astimezone(datetime.timezone.utc)
-
-
-def extract_location(exif_details: Dict[str, Any]) -> Optional[GEOSPoint]:
-    latitude_ref = exif_details.get("gps_latitude_ref")  # N or S
-    latitude_dms = exif_details.get("gps_latitude")  # tuple (DMS)
-    longitude_ref = exif_details.get("gps_longitude_ref")  # E or W
-    longitude_dms = exif_details.get("gps_longitude")  # tuple (DMS)
-
-    if (
-        not all([latitude_ref, latitude_dms, longitude_ref, longitude_dms])
-        or len(latitude_dms) < 3
-        or len(longitude_dms) < 3
-    ):
+    try:
+        dt = datetime.datetime.strptime(date_time_str, "%Y:%m:%d %H:%M:%S")
+        sign = -1 if offset_str.startswith("-") else 1
+        h, m = map(int, offset_str[1:].split(":"))
+        offset = datetime.timedelta(hours=sign * h, minutes=sign * m)
+        return dt.replace(tzinfo=datetime.timezone(offset)).astimezone(datetime.timezone.utc)
+    except (ValueError, AttributeError):
         return None
 
-    latitude = latitude_dms[0] + latitude_dms[1] / 60 + latitude_dms[2] / 3600
-    longitude = longitude_dms[0] + longitude_dms[1] / 60 + longitude_dms[2] / 3600
+
+def extract_location(gps_ifd: Dict[int, Any]) -> Optional[GEOSPoint]:
+    latitude_ref = gps_ifd.get(_GPS_LATITUDE_REF)  # "N" or "S"
+    latitude_dms = gps_ifd.get(_GPS_LATITUDE)  # tuple of 3 IFDRationals
+    longitude_ref = gps_ifd.get(_GPS_LONGITUDE_REF)  # "E" or "W"
+    longitude_dms = gps_ifd.get(_GPS_LONGITUDE)  # tuple of 3 IFDRationals
+
+    if not all([latitude_ref, latitude_dms, longitude_ref, longitude_dms]):
+        return None
+    if len(latitude_dms) < 3 or len(longitude_dms) < 3:
+        return None
+
+    latitude = float(latitude_dms[0]) + float(latitude_dms[1]) / 60 + float(latitude_dms[2]) / 3600
+    longitude = (
+        float(longitude_dms[0]) + float(longitude_dms[1]) / 60 + float(longitude_dms[2]) / 3600
+    )
 
     latitude *= -1 if latitude_ref == "S" else 1
     longitude *= -1 if longitude_ref == "W" else 1
@@ -203,33 +240,43 @@ def save_normalized_imagefile(instance: Image):
         instance.image = ContentFile(img_content.getvalue(), name=instance.image.name)
 
 
-def store_exif(instance: Image) -> Dict[str, Any]:
+def store_exif(instance: Image) -> None:
     file_obj = _get_file_for_reading(instance.image)
-    raw_bytes = file_obj.read()
-    file_obj.seek(0)
 
-    try:
-        exif_image = ExifImage(raw_bytes)
-        if exif_image.has_exif is False:
-            return
-    except UnpackError:
+    with PILImage.open(file_obj) as img:
+        exif = img.getexif()
+
+    if not exif:
         return
 
-    exif_details = {}
-    for k, v in exif_image.get_all().items():
-        if isinstance(v, Enum):
-            v = v.name
-        elif isinstance(v, (int, float, tuple, list)):
-            ...
-        else:
-            v = str(v).strip().replace("\u0000", "")
+    gps_ifd = exif.get_ifd(_GPS_IFD_TAG)
+    exif_ifd = exif.get_ifd(_EXIF_IFD_TAG)
 
-        exif_details[k] = v
+    # Build a flat dict of all EXIF tags using PIL string names, skipping IFD pointers
+    ifd_pointer_tags = {_GPS_IFD_TAG, _EXIF_IFD_TAG}
+    exif_details = {}
+
+    for tag_id, value in exif.items():
+        if tag_id in ifd_pointer_tags:
+            continue
+        v = _normalize_exif_value(value)
+        if v is not None:
+            exif_details[TAGS.get(tag_id, str(tag_id))] = v
+
+    for tag_id, value in gps_ifd.items():
+        v = _normalize_exif_value(value)
+        if v is not None:
+            exif_details[GPSTAGS.get(tag_id, str(tag_id))] = v
+
+    for tag_id, value in exif_ifd.items():
+        v = _normalize_exif_value(value)
+        if v is not None:
+            exif_details[TAGS.get(tag_id, str(tag_id))] = v
 
     instance.data = instance.data or {}
     instance.data["exif"] = exif_details
-    instance.location = extract_location(exif_details)
-    instance.photo_timestamp = extract_datetime_stamp(exif_details)
+    instance.location = extract_location(gps_ifd)
+    instance.photo_timestamp = extract_datetime_stamp(exif_ifd, gps_ifd)
 
 
 def create_classification_status(image, status, message=None):

--- a/src/api/utils/classification.py
+++ b/src/api/utils/classification.py
@@ -205,14 +205,15 @@ def save_normalized_imagefile(instance: Image):
 
 def store_exif(instance: Image) -> Dict[str, Any]:
     file_obj = _get_file_for_reading(instance.image)
+    raw_bytes = file_obj.read()
+    file_obj.seek(0)
 
-    with PILImage.open(file_obj) as img:
-        try:
-            exif_image = ExifImage(img.read())
-            if exif_image.has_exif is False:
-                return
-        except UnpackError:
+    try:
+        exif_image = ExifImage(raw_bytes)
+        if exif_image.has_exif is False:
             return
+    except UnpackError:
+        return
 
     exif_details = {}
     for k, v in exif_image.get_all().items():

--- a/src/tools/management/commands/backfill_exif_keys.py
+++ b/src/tools/management/commands/backfill_exif_keys.py
@@ -1,0 +1,209 @@
+"""
+Migrate stored EXIF data from the old exif-library snake_case key format to
+PIL CamelCase tag names.
+
+Background: before M1855, store_exif used the `exif` Python library whose
+attribute names differed from PIL's.  For example, PIL uses "DateTimeOriginal"
+while the exif library used "datetime_original".  The 3,000+ JPEG images
+uploaded before the fix have old-format keys stored in class_image.data["exif"].
+This command renames those keys in-place; no S3 access is required.
+
+Usage:
+    python manage.py backfill_exif_keys [--dry-run] [--batch-size N]
+"""
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from api.models import Image
+
+# Maps every exif-library attribute name that has appeared in production data
+# to its PIL.ExifTags equivalent.  Internal pointer fields (prefixed with _)
+# are dropped — they are byte offsets, not meaningful EXIF values.
+#
+# Where the exif library and PIL use different *semantic* names for the same
+# tag (e.g. photographic_sensitivity vs ISOSpeedRatings), the PIL name wins
+# because it matches the EXIF spec tag name more closely.
+_EXIF_LIB_TO_PIL = {
+    # ── dropped internal pointer fields ──────────────────────────────────────
+    "_exif_ifd_pointer": None,
+    "_gps_ifd_pointer": None,
+    # ── datetime / offset ────────────────────────────────────────────────────
+    "datetime": "DateTime",
+    "datetime_original": "DateTimeOriginal",
+    "datetime_digitized": "DateTimeDigitized",
+    "offset_time": "OffsetTime",
+    "offset_time_original": "OffsetTimeOriginal",
+    "offset_time_digitized": "OffsetTimeDigitized",
+    "subsec_time": "SubsecTime",
+    "subsec_time_original": "SubsecTimeOriginal",
+    "subsec_time_digitized": "SubsecTimeDigitized",
+    # ── camera identity ───────────────────────────────────────────────────────
+    "make": "Make",
+    "model": "Model",
+    "software": "Software",
+    "image_description": "ImageDescription",
+    "artist": "Artist",
+    "copyright": "Copyright",
+    "body_serial_number": "BodySerialNumber",
+    "camera_owner_name": "CameraOwnerName",
+    "lens_make": "LensMake",
+    "lens_model": "LensModel",
+    "lens_serial_number": "LensSerialNumber",
+    "lens_specification": "LensSpecification",
+    "xp_author": "XPAuthor",
+    # ── image geometry / resolution ───────────────────────────────────────────
+    "orientation": "Orientation",
+    "x_resolution": "XResolution",
+    "y_resolution": "YResolution",
+    "resolution_unit": "ResolutionUnit",
+    "y_and_c_positioning": "YCbCrPositioning",  # PIL name differs
+    "pixel_x_dimension": "ExifImageWidth",  # PIL name differs
+    "pixel_y_dimension": "ExifImageHeight",  # PIL name differs
+    "compression": "Compression",
+    "compressed_bits_per_pixel": "CompressedBitsPerPixel",
+    "jpeg_interchange_format": "JpegIFOffset",  # PIL name differs
+    "jpeg_interchange_format_length": "JpegIFByteCount",  # PIL name differs
+    # ── exposure / photometry ─────────────────────────────────────────────────
+    "exposure_time": "ExposureTime",
+    "f_number": "FNumber",
+    "exposure_program": "ExposureProgram",
+    "photographic_sensitivity": "ISOSpeedRatings",  # PIL name differs
+    "sensitivity_type": "SensitivityType",
+    "recommended_exposure_index": "RecommendedExposureIndex",
+    "shutter_speed_value": "ShutterSpeedValue",
+    "aperture_value": "ApertureValue",
+    "brightness_value": "BrightnessValue",
+    "exposure_bias_value": "ExposureBiasValue",
+    "max_aperture_value": "MaxApertureValue",
+    "subject_distance": "SubjectDistance",
+    "metering_mode": "MeteringMode",
+    "light_source": "LightSource",
+    "flash": "Flash",
+    "focal_length": "FocalLength",
+    "exposure_mode": "ExposureMode",
+    "white_balance": "WhiteBalance",
+    "digital_zoom_ratio": "DigitalZoomRatio",
+    "focal_length_in_35mm_film": "FocalLengthIn35mmFilm",
+    "scene_capture_type": "SceneCaptureType",
+    "gain_control": "GainControl",
+    "contrast": "Contrast",
+    "saturation": "Saturation",
+    "sharpness": "Sharpness",
+    "subject_distance_range": "SubjectDistanceRange",
+    "custom_rendered": "CustomRendered",
+    "exposure_index": "ExposureIndex",
+    "sensing_method": "SensingMethod",
+    "subject_area": "SubjectLocation",  # PIL name differs
+    # ── colour / rendering ────────────────────────────────────────────────────
+    "color_space": "ColorSpace",
+    "exif_version": "ExifVersion",
+    "user_comment": "UserComment",
+    # ── optics ───────────────────────────────────────────────────────────────
+    "focal_plane_x_resolution": "FocalPlaneXResolution",
+    "focal_plane_y_resolution": "FocalPlaneYResolution",
+    "focal_plane_resolution_unit": "FocalPlaneResolutionUnit",
+    # ── GPS ──────────────────────────────────────────────────────────────────
+    "gps_version_id": "GPSVersionID",
+    "gps_latitude_ref": "GPSLatitudeRef",
+    "gps_latitude": "GPSLatitude",
+    "gps_longitude_ref": "GPSLongitudeRef",
+    "gps_longitude": "GPSLongitude",
+    "gps_altitude_ref": "GPSAltitudeRef",
+    "gps_altitude": "GPSAltitude",
+    "gps_timestamp": "GPSTimeStamp",
+    "gps_datestamp": "GPSDateStamp",
+    "gps_speed_ref": "GPSSpeedRef",
+    "gps_speed": "GPSSpeed",
+    "gps_img_direction_ref": "GPSImgDirectionRef",
+    "gps_img_direction": "GPSImgDirection",
+    "gps_dest_bearing_ref": "GPSDestBearingRef",
+    "gps_dest_bearing": "GPSDestBearing",
+    "gps_horizontal_positioning_error": "GPSHPositioningError",  # PIL name shorter
+    "gps_status": "GPSStatus",
+}
+
+
+def _is_old_format(exif_dict: dict) -> bool:
+    """Return True if the stored EXIF dict uses old exif-library snake_case keys."""
+    return any(k[0].islower() for k in exif_dict)
+
+
+def _migrate_exif_dict(exif_dict: dict) -> dict:
+    """Return a new dict with keys renamed from exif-lib to PIL CamelCase."""
+    result = {}
+    for old_key, value in exif_dict.items():
+        new_key = _EXIF_LIB_TO_PIL.get(old_key)
+        if new_key is None:
+            # Either explicitly dropped (internal pointer) or unknown — skip
+            continue
+        result[new_key] = value
+    return result
+
+
+class Command(BaseCommand):
+    help = (
+        "Rename EXIF keys in class_image.data from the old exif-library snake_case "
+        "format (e.g. 'datetime_original') to PIL CamelCase (e.g. 'DateTimeOriginal'). "
+        "Affects images uploaded before M1855.  No S3 access required."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing to the database.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=200,
+            help="Number of images to update per transaction (default: 200).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        batch_size = options["batch_size"]
+
+        qs = Image.objects.filter(data__has_key="exif")
+        total = qs.count()
+        self.stdout.write(f"Found {total} images with stored EXIF data.")
+
+        updated = skipped = 0
+        batch = []
+
+        for image in qs.iterator():
+            exif_dict = image.data.get("exif", {})
+            if not _is_old_format(exif_dict):
+                skipped += 1
+                continue
+
+            new_exif = _migrate_exif_dict(exif_dict)
+            if dry_run:
+                self.stdout.write(
+                    f"  [dry-run] {image.pk}: would rename "
+                    f"{len(exif_dict)} → {len(new_exif)} keys"
+                )
+                updated += 1
+                continue
+
+            image.data["exif"] = new_exif
+            batch.append(image)
+            updated += 1
+
+            if len(batch) >= batch_size:
+                self._flush(batch)
+                batch = []
+
+        if batch:
+            self._flush(batch)
+
+        status = "Would update" if dry_run else "Updated"
+        self.stdout.write(
+            self.style.SUCCESS(f"{status} {updated} images; skipped {skipped} already-current.")
+        )
+
+    def _flush(self, batch):
+        with transaction.atomic():
+            Image.objects.bulk_update(batch, ["data"])
+        self.stdout.write(f"  flushed {len(batch)} records")

--- a/src/tools/management/commands/backfill_exif_keys.py
+++ b/src/tools/management/commands/backfill_exif_keys.py
@@ -127,10 +127,17 @@ _EXIF_LIB_TO_PIL = {
 def _is_old_format(exif_dict: dict) -> bool:
     """Return True if the stored EXIF dict uses old exif-library snake_case keys.
 
+    Underscore-prefixed keys (e.g. '_exif_ifd_pointer') are also treated as legacy.
     Keys that are numeric strings (e.g. '34853', stored as fallback tag IDs by PIL)
     are treated as neither old nor new format and do not trigger migration.
+    Empty or non-string keys are skipped safely.
     """
-    return any(k[0].isalpha() and k[0].islower() for k in exif_dict)
+    return any(
+        isinstance(k, str)
+        and len(k) > 0
+        and (k.startswith("_") or (k[0].isalpha() and k[0].islower()))
+        for k in exif_dict
+    )
 
 
 def _migrate_exif_dict(exif_dict: dict) -> tuple[dict, list[str]]:
@@ -145,6 +152,7 @@ def _migrate_exif_dict(exif_dict: dict) -> tuple[dict, list[str]]:
     for old_key, value in exif_dict.items():
         if old_key not in _EXIF_LIB_TO_PIL:
             unknown.append(old_key)
+            result[old_key] = value
             continue
         new_key = _EXIF_LIB_TO_PIL[old_key]
         if new_key is None:
@@ -187,6 +195,12 @@ class Command(BaseCommand):
 
         for image in qs.iterator():
             exif_dict = image.data.get("exif", {})
+            if not isinstance(exif_dict, dict):
+                self.stderr.write(
+                    f"  WARNING {image.pk}: exif value is not a dict ({type(exif_dict).__name__}), skipping"
+                )
+                skipped += 1
+                continue
             if not _is_old_format(exif_dict):
                 skipped += 1
                 continue

--- a/src/tools/management/commands/backfill_exif_keys.py
+++ b/src/tools/management/commands/backfill_exif_keys.py
@@ -125,20 +125,33 @@ _EXIF_LIB_TO_PIL = {
 
 
 def _is_old_format(exif_dict: dict) -> bool:
-    """Return True if the stored EXIF dict uses old exif-library snake_case keys."""
-    return any(k[0].islower() for k in exif_dict)
+    """Return True if the stored EXIF dict uses old exif-library snake_case keys.
+
+    Keys that are numeric strings (e.g. '34853', stored as fallback tag IDs by PIL)
+    are treated as neither old nor new format and do not trigger migration.
+    """
+    return any(k[0].isalpha() and k[0].islower() for k in exif_dict)
 
 
-def _migrate_exif_dict(exif_dict: dict) -> dict:
-    """Return a new dict with keys renamed from exif-lib to PIL CamelCase."""
+def _migrate_exif_dict(exif_dict: dict) -> tuple[dict, list[str]]:
+    """Return (migrated_dict, unknown_keys) from exif-lib to PIL CamelCase.
+
+    Explicitly dropped keys (internal pointer fields mapped to None) are silently
+    discarded.  Keys not present in _EXIF_LIB_TO_PIL at all are returned separately
+    as unknown_keys so callers can log or inspect them.
+    """
     result = {}
+    unknown = []
     for old_key, value in exif_dict.items():
-        new_key = _EXIF_LIB_TO_PIL.get(old_key)
+        if old_key not in _EXIF_LIB_TO_PIL:
+            unknown.append(old_key)
+            continue
+        new_key = _EXIF_LIB_TO_PIL[old_key]
         if new_key is None:
-            # Either explicitly dropped (internal pointer) or unknown — skip
+            # Explicitly dropped internal pointer field — discard silently
             continue
         result[new_key] = value
-    return result
+    return result, unknown
 
 
 class Command(BaseCommand):
@@ -178,7 +191,12 @@ class Command(BaseCommand):
                 skipped += 1
                 continue
 
-            new_exif = _migrate_exif_dict(exif_dict)
+            new_exif, unknown_keys = _migrate_exif_dict(exif_dict)
+            if unknown_keys:
+                self.stderr.write(
+                    f"  WARNING {image.pk}: {len(unknown_keys)} unmapped key(s): "
+                    + ", ".join(unknown_keys)
+                )
             if dry_run:
                 self.stdout.write(
                     f"  [dry-run] {image.pk}: would rename "


### PR DESCRIPTION
  Problem                                                                                                                                                                       
   
  store_exif was calling img.read() on a PIL Image object rather than the underlying file. PIL's JpegImagePlugin raises AttributeError: read for this, so EXIF data was silently
   failing to be stored for every JPEG upload. PNG and TIFF images failed the same way but with no observable regression since neither format stores EXIF via the exif library
  that was in use.                                                                                                                                                              
                                                                                                                                                                              
  Changes                                

  - Replaced the exif library with PIL's getexif() / get_ifd() throughout store_exif. This fixes the JPEG bug and adds correct support for PNG files carrying an eXIf chunk and 
  TIFF files — formats the old library could not handle at all.
  - extract_location and extract_datetime_stamp now take the GPS and EXIF sub-IFD dicts directly (keyed by integer tag ID) rather than a flat string-keyed dict. This removes   
  the fragile string matching that tied them to one library's naming convention.                                                                                                
  - Fixed two latent bugs in extract_datetime_stamp: a short-circuit guard that made the datetime+offset fallback path unreachable, and timedelta(hours="+13:00") which would
  have crashed on the string argument if that path had ever been reached.                                                                                                       
  - EXIF data is now stored with PIL's CamelCase tag names (DateTimeOriginal, GPSLatitude, etc.) rather than the old library's snake_case names.                              
  - exif==1.6.1 removed from requirements.txt.                                                                                                                                  
  - backfill_exif_keys management command renames keys in the ~3,000 existing records from the old snake_case format to CamelCase. Supports --dry-run and --batch-size. No S3   
  access required.                                                                                                                                                              
                                                                                                                                                                                
  Tests                                                                                                                                                                         
                                                                                                                                                                              
  Added to test_utils.py: JPEG extraction (regression test for the original bug), plain PNG (no EXIF stored), PNG with eXIf chunk (new capability), TIFF (no crash),            
  GPS-priority timestamp, datetime+offset fallback, and GPS location conversion.      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed pinned exif dependency.
  * Added a data migration to rename and normalize stored EXIF keys for existing images.

* **Bug Fixes / Improvements**
  * Improved EXIF extraction using PIL: more reliable timestamp and GPS parsing, better handling of JPEG, PNG (with/without eXIf), and TIFF files, and normalized EXIF storage that feeds photo timestamp and location.

* **Tests**
  * Added comprehensive unit tests covering EXIF parsing, timestamp/location logic, and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->