### PR TITLE
[M1926] make ImagePermission missing profile produce None not AttributeError

### DIFF
--- a/src/api/resources/classification/image.py
+++ b/src/api/resources/classification/image.py
@@ -28,7 +28,7 @@ from .point import PointSerializer
 
 class ImagePermission(permissions.BasePermission):
     def has_permission(self, request, view):
-        profile = getattr(request.user, "profile")
+        profile = getattr(request.user, "profile", None)
         if profile is None:
             return False
 
@@ -148,7 +148,7 @@ class ImageViewSet(BaseProjectApiViewSet):
 
     def limit_to_project(self, request, *args, **kwargs):
         qs = self.get_queryset()
-        profile = getattr(request.user, "profile")
+        profile = getattr(request.user, "profile", None)
         if profile is None:
             return qs.none()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system stability by improving error handling for user profile access. The application now gracefully manages scenarios where profiles are unavailable, preventing potential errors in image upload and permission verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->