### PR TITLE
[M1458] remove outer transaction from FishIngester

### DIFF
--- a/src/api/ingest/attributes_ingester.py
+++ b/src/api/ingest/attributes_ingester.py
@@ -252,6 +252,7 @@ class FishIngester(BaseAttributeIngester):
     ERROR = "ERROR"
     EXISTING_FAMILY = "EXISTING_FAMILY"
     NEW_FAMILY = "NEW_FAMILY"
+    DUPLICATE_FAMILY = "DUPLICATE_FAMILY"
 
     EXISTING_GENUS = "EXISTING_GENUS"
     NEW_GENUS = "NEW_GENUS"
@@ -322,8 +323,10 @@ class FishIngester(BaseAttributeIngester):
         )
 
     def _prevalidate_rows(self, rows):
-        """Check all lookup and region values without touching the DB. Returns list of error strings."""
+        """Validate all rows before any writes. Returns list of error strings."""
         errors = []
+
+        # Per-row field/lookup/region checks
         for i, row in enumerate(rows, start=2):
             try:
                 mapped = self._map_fields(
@@ -344,6 +347,39 @@ class FishIngester(BaseAttributeIngester):
                     name = region.strip().lower()
                     if name and name not in self.regions:
                         errors.append(f"Row {i} - Unknown region: '{region.strip()}'")
+
+        # Check for duplicate family names in the DB — these would cause silent skips
+        csv_family_names = {
+            (row.get("Family") or "").strip() for row in rows if (row.get("Family") or "").strip()
+        }
+        for name in sorted(csv_family_names):
+            if FishFamily.objects.filter(name__iexact=name).count() > 1:
+                errors.append(
+                    f"Family '{name}': multiple entries with this name exist in the database"
+                )
+
+        # Check for duplicate genus names (per family) in the DB
+        csv_genera_by_family = {}
+        for row in rows:
+            family = (row.get("Family") or "").strip()
+            genus = (row.get("Genus") or "").strip()
+            if family and genus:
+                csv_genera_by_family.setdefault(family, set()).add(genus)
+
+        for family_name, genus_names in sorted(csv_genera_by_family.items()):
+            try:
+                family = FishFamily.objects.get(name__iexact=family_name)
+            except FishFamily.DoesNotExist:
+                continue  # new family — no existing genera to check
+            except FishFamily.MultipleObjectsReturned:
+                continue  # already flagged as a duplicate family above
+            for genus_name in sorted(genus_names):
+                if FishGenus.objects.filter(name__iexact=genus_name, family=family).count() > 1:
+                    errors.append(
+                        f"Genus '{genus_name}' under family '{family_name}': "
+                        f"multiple entries with this name exist in the database"
+                    )
+
         return errors
 
     def ingest(self, dry_run=False, allow_multiword_species=False):
@@ -412,6 +448,8 @@ class FishIngester(BaseAttributeIngester):
         return fish_family
 
     def _ingest_fish_genus(self, row, fish_family):
+        if fish_family is None:
+            return None
         genus_row = self._map_fields(row, self.fish_genus_field_map, self.fish_genus_lookups)
         genus_name = genus_row["name"]
         try:
@@ -426,6 +464,8 @@ class FishIngester(BaseAttributeIngester):
         return genus
 
     def _ingest_fish_species(self, row, fish_genus):
+        if fish_genus is None:
+            return
         species_row = self._map_fields(
             row,
             self.fish_species_field_map,
@@ -437,7 +477,7 @@ class FishIngester(BaseAttributeIngester):
         try:
             species = FishSpecies.objects.get(name__iexact=species_name, genus=fish_genus)
             has_edits = False
-            region_names = species_row.pop("regions")
+            region_names = species_row.pop("regions", None)
             updates = []
             for k, v in species_row.items():
                 original_val = getattr(species, k)
@@ -462,7 +502,7 @@ class FishIngester(BaseAttributeIngester):
                 self.write_log(self.EXISTING_SPECIES, f"{genus_name}-{species_name}")
 
         except FishSpecies.DoesNotExist:
-            region_names = species_row.pop("regions")
+            region_names = species_row.pop("regions", None)
             species = FishSpecies.objects.create(genus=fish_genus, **species_row)
             self._update_regions(species, region_names, is_combined=False)
 

--- a/src/api/ingest/attributes_ingester.py
+++ b/src/api/ingest/attributes_ingester.py
@@ -367,29 +367,31 @@ class FishIngester(BaseAttributeIngester):
         if prevalidation_errors:
             return False, self.log
 
+        if dry_run:
+            self.write_log("DRY_RUN", "No changes committed.")
+            return True, self.log
+
         n = 2
         is_successful = True
-        with transaction.atomic():
-            for row in rows:
-                try:
+        for row in rows:
+            try:
+                with transaction.atomic():
                     fish_family = self._ingest_fish_family(row)
                     fish_genus = self._ingest_fish_genus(row, fish_family=fish_family)
                     self._ingest_fish_species(row, fish_genus=fish_genus)
-                except Exception as err:
-                    self.write_log(self.ERROR, f"Row {n} - {str(err)}")
-                    is_successful = False
-                    break
-                finally:
-                    n = n + 1
-
-            if dry_run or not is_successful:
-                transaction.set_rollback(True)
+            except Exception as err:
+                self.write_log(self.ERROR, f"Row {n} - {str(err)}")
+                is_successful = False
+                break
+            finally:
+                n = n + 1
 
         if not is_successful:
             self.log = [e for e in self.log if e.startswith("ERROR")]
-            self.write_log("ROLLED_BACK", "All changes rolled back due to errors above.")
-        elif dry_run:
-            self.write_log("DRY_RUN", "No changes committed.")
+            self.write_log(
+                "ABORTED",
+                "Processing stopped due to error above. Successfully processed rows were committed.",
+            )
 
         return is_successful, self.log
 

--- a/src/api/ingest/attributes_ingester.py
+++ b/src/api/ingest/attributes_ingester.py
@@ -452,6 +452,7 @@ class FishIngester(BaseAttributeIngester):
             return None
         genus_row = self._map_fields(row, self.fish_genus_field_map, self.fish_genus_lookups)
         genus_name = genus_row["name"]
+        genus = None
         try:
             genus = FishGenus.objects.get(name__iexact=genus_name, family=fish_family)
             self.write_log(self.EXISTING_GENUS, genus_name)

--- a/src/api/ingest/attributes_ingester.py
+++ b/src/api/ingest/attributes_ingester.py
@@ -2,6 +2,8 @@ import csv
 import datetime
 
 from django.db import transaction
+from django.db.models import Count, Q
+from django.db.models.functions import Lower
 
 from api.models import (
     APPROVAL_STATUSES,
@@ -252,11 +254,8 @@ class FishIngester(BaseAttributeIngester):
     ERROR = "ERROR"
     EXISTING_FAMILY = "EXISTING_FAMILY"
     NEW_FAMILY = "NEW_FAMILY"
-    DUPLICATE_FAMILY = "DUPLICATE_FAMILY"
-
     EXISTING_GENUS = "EXISTING_GENUS"
     NEW_GENUS = "NEW_GENUS"
-    DUPLICATE_GENUS = "DUPLICATE_GENUS"
 
     EXISTING_SPECIES = "EXISTING_SPECIES"
     NEW_SPECIES = "NEW_SPECIES"
@@ -349,36 +348,73 @@ class FishIngester(BaseAttributeIngester):
                         errors.append(f"Row {i} - Unknown region: '{region.strip()}'")
 
         # Check for duplicate family names in the DB — these would cause silent skips
-        csv_family_names = {
-            (row.get("Family") or "").strip() for row in rows if (row.get("Family") or "").strip()
-        }
-        for name in sorted(csv_family_names):
-            if FishFamily.objects.filter(name__iexact=name).count() > 1:
-                errors.append(
-                    f"Family '{name}': multiple entries with this name exist in the database"
-                )
+        # Preserve original CSV casing for error messages, normalize for DB queries
+        csv_family_display = {}  # name_lower -> original CSV name
+        for row in rows:
+            name = (row.get("Family") or "").strip()
+            if name:
+                csv_family_display.setdefault(name.lower(), name)
+        csv_family_names = set(csv_family_display.keys())
+
+        family_counts = (
+            FishFamily.objects.annotate(name_lower=Lower("name"))
+            .filter(name_lower__in=csv_family_names)
+            .values("name_lower")
+            .annotate(cnt=Count("id"))
+            .filter(cnt__gt=1)
+        )
+        for entry in family_counts:
+            display = csv_family_display.get(entry["name_lower"], entry["name_lower"])
+            errors.append(
+                f"Family '{display}': multiple entries with this name exist in the database"
+            )
 
         # Check for duplicate genus names (per family) in the DB
         csv_genera_by_family = {}
+        csv_genus_display = {}  # name_lower -> original CSV name
         for row in rows:
-            family = (row.get("Family") or "").strip()
-            genus = (row.get("Genus") or "").strip()
+            family = (row.get("Family") or "").strip().lower()
+            genus_raw = (row.get("Genus") or "").strip()
+            genus = genus_raw.lower()
             if family and genus:
                 csv_genera_by_family.setdefault(family, set()).add(genus)
+                csv_genus_display.setdefault(genus, genus_raw)
 
-        for family_name, genus_names in sorted(csv_genera_by_family.items()):
-            try:
-                family = FishFamily.objects.get(name__iexact=family_name)
-            except FishFamily.DoesNotExist:
-                continue  # new family — no existing genera to check
-            except FishFamily.MultipleObjectsReturned:
-                continue  # already flagged as a duplicate family above
-            for genus_name in sorted(genus_names):
-                if FishGenus.objects.filter(name__iexact=genus_name, family=family).count() > 1:
-                    errors.append(
-                        f"Genus '{genus_name}' under family '{family_name}': "
-                        f"multiple entries with this name exist in the database"
-                    )
+        # Fetch all matching families in one query; track duplicates (already flagged above)
+        unique_families = {}  # name_lower -> family obj, or None if duplicated in DB
+        for f in FishFamily.objects.annotate(name_lower=Lower("name")).filter(
+            name_lower__in=list(csv_genera_by_family.keys())
+        ):
+            if f.name_lower in unique_families:
+                unique_families[f.name_lower] = None  # duplicate — already flagged above
+            else:
+                unique_families[f.name_lower] = f
+
+        # Build a single bulk query for genus duplicates across all unique families
+        genus_filter = Q()
+        family_id_to_display = {}
+        for family_name, genus_names in csv_genera_by_family.items():
+            family = unique_families.get(family_name)
+            if family is None:
+                continue  # new family or already-flagged duplicate
+            genus_filter |= Q(family=family, name_lower__in=list(genus_names))
+            family_id_to_display[family.id] = csv_family_display.get(family_name, family_name)
+
+        if genus_filter:
+            genus_counts = (
+                FishGenus.objects.annotate(name_lower=Lower("name"))
+                .filter(genus_filter)
+                .values("family_id", "name_lower")
+                .annotate(cnt=Count("id"))
+                .filter(cnt__gt=1)
+            )
+            for entry in genus_counts:
+                family_display = family_id_to_display[entry["family_id"]]
+                genus_display = csv_genus_display.get(entry["name_lower"], entry["name_lower"])
+                errors.append(
+                    f"Genus '{genus_display}' under family '{family_display}': "
+                    f"multiple entries with this name exist in the database"
+                )
 
         return errors
 
@@ -423,10 +459,9 @@ class FishIngester(BaseAttributeIngester):
                 n = n + 1
 
         if not is_successful:
-            self.log = [e for e in self.log if e.startswith("ERROR")]
             self.write_log(
                 "ABORTED",
-                "Processing stopped due to error above. Successfully processed rows were committed.",
+                "Processing stopped at first error. Successfully processed rows were committed; re-run to process remaining rows.",
             )
 
         return is_successful, self.log
@@ -435,7 +470,6 @@ class FishIngester(BaseAttributeIngester):
         family_row = self._map_fields(row, self.fish_family_field_map, self.fish_family_lookups)
         family_name = family_row.get("name")
 
-        fish_family = None
         try:
             fish_family = FishFamily.objects.get(name__iexact=family_name)
             self.write_log(self.EXISTING_FAMILY, family_name)
@@ -443,16 +477,15 @@ class FishIngester(BaseAttributeIngester):
             fish_family = FishFamily.objects.create(**family_row)
             self.write_log(self.NEW_FAMILY, family_name)
         except FishFamily.MultipleObjectsReturned:
-            self.write_log(self.DUPLICATE_FAMILY, family_name)
+            raise ValueError(
+                f"Multiple families named '{family_name}' exist; cannot determine which to use."
+            )
 
         return fish_family
 
     def _ingest_fish_genus(self, row, fish_family):
-        if fish_family is None:
-            return None
         genus_row = self._map_fields(row, self.fish_genus_field_map, self.fish_genus_lookups)
         genus_name = genus_row["name"]
-        genus = None
         try:
             genus = FishGenus.objects.get(name__iexact=genus_name, family=fish_family)
             self.write_log(self.EXISTING_GENUS, genus_name)
@@ -460,13 +493,13 @@ class FishIngester(BaseAttributeIngester):
             genus = FishGenus.objects.create(family=fish_family, **genus_row)
             self.write_log(self.NEW_GENUS, genus_name)
         except FishGenus.MultipleObjectsReturned:
-            self.write_log(self.DUPLICATE_GENUS, genus_name)
+            raise ValueError(
+                f"Multiple genera named '{genus_name}' exist; cannot determine which to use."
+            )
 
         return genus
 
     def _ingest_fish_species(self, row, fish_genus):
-        if fish_genus is None:
-            return
         species_row = self._map_fields(
             row,
             self.fish_species_field_map,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-import duplicate detection to surface family/genus conflicts before writing.
  * Dry-run now exits after successful prevalidation to avoid partial work.
  * Import now aborts immediately on first error and logs an aborted run.
  * Improved robustness for missing region data and missing parent relationships during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->