### PR TITLE
[M1939] fix recursion error in get_related_project

### DIFF
--- a/src/api/utils/related.py
+++ b/src/api/utils/related.py
@@ -42,8 +42,14 @@ def get_related_project(model, _visited=None):
     if isinstance(model, models.Project):
         return model
 
-    if hasattr(model, "project") and isinstance(model.project, models.Project):
-        return model.project
+    try:
+        proj = model.project
+        if isinstance(proj, models.Project):
+            return proj
+    except ObjectDoesNotExist:
+        return None
+    except AttributeError:
+        pass
 
     if hasattr(model, "project_lookup"):
         project_lookup = getattr(model, "project_lookup")

--- a/src/api/utils/related.py
+++ b/src/api/utils/related.py
@@ -28,7 +28,15 @@ def get_model_value(model, lookups):
     return obj
 
 
-def get_related_project(model):
+def get_related_project(model, _visited=None):
+    if _visited is None:
+        _visited = set()
+
+    obj_id = id(model)
+    if obj_id in _visited:
+        return None
+    _visited.add(obj_id)
+
     if isinstance(model, models.Project):
         return model
 
@@ -44,11 +52,14 @@ def get_related_project(model):
 
     for f in model._meta.get_fields():
         if isinstance(f, ForeignKey):
-            rel_obj = getattr(model, f.name)
+            try:
+                rel_obj = getattr(model, f.name)
+            except Exception:
+                continue
             if rel_obj is not None:
                 if isinstance(rel_obj, models.Project):
                     return rel_obj
-                rel_obj = get_related_project(rel_obj)
+                rel_obj = get_related_project(rel_obj, _visited)
                 if rel_obj:
                     return rel_obj
     return None

--- a/src/api/utils/related.py
+++ b/src/api/utils/related.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.fields.related import ForeignKey
 
 from api import models
@@ -32,10 +33,11 @@ def get_related_project(model, _visited=None):
     if _visited is None:
         _visited = set()
 
-    obj_id = id(model)
-    if obj_id in _visited:
+    pk = getattr(model, "pk", None)
+    obj_key = (model.__class__, pk) if pk is not None else id(model)
+    if obj_key in _visited:
         return None
-    _visited.add(obj_id)
+    _visited.add(obj_key)
 
     if isinstance(model, models.Project):
         return model
@@ -54,7 +56,7 @@ def get_related_project(model, _visited=None):
         if isinstance(f, ForeignKey):
             try:
                 rel_obj = getattr(model, f.name)
-            except Exception:
+            except ObjectDoesNotExist:
                 continue
             if rel_obj is not None:
                 if isinstance(rel_obj, models.Project):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented infinite loops when traversing circular project relationships to avoid hangs or crashes.
  * Improved handling of missing related records: traversal now skips absent relations instead of raising errors.
  * Made relationship traversal more robust by consistently tracking visited objects and guarding attribute access to safely handle missing or deleted relations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->