### PR TITLE
[M1961] invert supporting viewsets

### DIFF
--- a/new_protocol_readme.md
+++ b/new_protocol_readme.md
@@ -43,9 +43,12 @@
 
 If the protocol introduces its own attribute/taxonomy hierarchy (Django MTI from `BaseAttributeModel`), add:
 
-- A viewset (`BaseAttributeApiViewSet`) with a serializer that exposes all taxonomy levels and the full ancestry chain (e.g. `parent`, `class_goi`); use `select_related` across all MTI subtypes to avoid N+1 queries; exclude any internal-only nodes (e.g. backing models not part of the user-visible hierarchy)
+- A viewset (`BaseAttributeApiViewSet`) with a serializer that exposes all taxonomy levels and the full ancestry chain (e.g. `parent`, `class_goi`); use `select_related` across all MTI subtypes to avoid N+1 queries; exclude any internal-only nodes (e.g. backing models not part of the user-visible hierarchy) by filtering `.filter(<internal_model>__isnull=True)` — see `InvertAttributeViewSet` for the implementation pattern and `test_invert_attributes.py::test_list_invert_attributes_returns_user_visible_hierarchy` for the corresponding test pattern
 - Register the viewset in `urls.py` (global router, alongside `benthicattributes`)
-- Register in `src/api/resources/sync/views.py` `non_project_sources` so offline clients sync the taxonomy
+- Register in `src/api/resources/sync/views.py` `non_project_sources` so offline clients sync the taxonomy:
+  - `"read_only": False` — enables the propose-new-attribute flow for authenticated users
+  - `"visibility_filtered": True` — filters nodes based on status/visibility so only approved entries are synced to clients
+  - Add the source type constant to `CACHEABLE_SOURCE_TYPES` so pull responses are cached
 
 ## Choices Endpoint
 

--- a/new_protocol_readme.md
+++ b/new_protocol_readme.md
@@ -39,6 +39,14 @@
 
 - Update `annotate_num_sample_units()` in `src/api/resources/project.py` with a new UNION ALL branch counting sample units for the new protocol (joining through method → transect → sample event → site → project)
 
+## Attribute Taxonomy API (if protocol has its own MTI taxonomy)
+
+If the protocol introduces its own attribute/taxonomy hierarchy (Django MTI from `BaseAttributeModel`), add:
+
+- A viewset (`BaseAttributeApiViewSet`) with a serializer that exposes all taxonomy levels and the full ancestry chain (e.g. `parent`, `class_goi`); use `select_related` across all MTI subtypes to avoid N+1 queries; exclude any internal-only nodes (e.g. backing models not part of the user-visible hierarchy)
+- Register the viewset in `urls.py` (global router, alongside `benthicattributes`)
+- Register in `src/api/resources/sync/views.py` `non_project_sources` so offline clients sync the taxonomy
+
 ## Choices Endpoint
 
 - Import new lookup models in `src/api/resources/choices.py`

--- a/new_protocol_readme.md
+++ b/new_protocol_readme.md
@@ -43,7 +43,7 @@
 
 If the protocol introduces its own attribute/taxonomy hierarchy (Django MTI from `BaseAttributeModel`), add:
 
-- A viewset (`BaseAttributeApiViewSet`) with a serializer that exposes all taxonomy levels and the full ancestry chain (e.g. `parent`, `class_goi`); use `select_related` across all MTI subtypes to avoid N+1 queries; exclude any internal-only nodes (e.g. backing models not part of the user-visible hierarchy) by filtering `.filter(<internal_model>__isnull=True)` — see `InvertAttributeViewSet` for the implementation pattern and `test_invert_attributes.py::test_list_invert_attributes_returns_user_visible_hierarchy` for the corresponding test pattern
+- A viewset (`BaseAttributeApiViewSet`) with a serializer that exposes all taxonomy levels and the full ancestry chain (e.g. `parent`, `class_goi`); use `select_related` across all MTI subtypes to avoid N+1 queries — see `InvertAttributeViewSet` for the implementation pattern and `test_invert_attributes.py::test_list_invert_attributes_returns_user_visible_hierarchy` for the corresponding test pattern
 - Register the viewset in `urls.py` (global router, alongside `benthicattributes`)
 - Register in `src/api/resources/sync/views.py` `non_project_sources` so offline clients sync the taxonomy:
   - `"read_only": False` — enables the propose-new-attribute flow for authenticated users

--- a/src/api/admin/protocols/macroinvertebrate.py
+++ b/src/api/admin/protocols/macroinvertebrate.py
@@ -6,11 +6,9 @@ from ...models import (
     InvertBeltTransect,
     InvertBeltTransectWidth,
     InvertClass,
-    InvertClassGroupOfInterest,
     InvertFamily,
     InvertGenus,
     InvertGroupOfInterest,
-    InvertHarvestType,
     InvertOrder,
     InvertSize,
     InvertSizeBin,
@@ -47,17 +45,11 @@ class InvertGroupOfInterestAdmin(BaseAdmin):
     search_fields = ("name",)
 
 
-@admin.register(InvertHarvestType)
-class InvertHarvestTypeAdmin(BaseAdmin):
-    list_display = ("name",)
-    search_fields = ("name",)
-
-
-class InvertClassGroupOfInterestInline(admin.TabularInline):
-    model = InvertClassGroupOfInterest
+class InvertOrderInline(admin.TabularInline):
+    model = InvertOrder
     fk_name = "invert_class"
     extra = 0
-    fields = ("group_of_interest",)
+    fields = ("name",)
     show_change_link = True
 
 
@@ -65,22 +57,6 @@ class InvertClassGroupOfInterestInline(admin.TabularInline):
 class InvertClassAdmin(BaseAdmin):
     list_display = ("name",)
     search_fields = ("name",)
-    inlines = [InvertClassGroupOfInterestInline]
-
-
-class InvertOrderInline(admin.TabularInline):
-    model = InvertOrder
-    fk_name = "class_goi"
-    extra = 0
-    fields = ("name",)
-    show_change_link = True
-
-
-@admin.register(InvertClassGroupOfInterest)
-class InvertClassGroupOfInterestAdmin(BaseAdmin):
-    list_display = ("invert_class", "group_of_interest")
-    list_filter = ("invert_class", "group_of_interest")
-    search_fields = ("invert_class__name", "group_of_interest__name")
     inlines = [InvertOrderInline]
 
 
@@ -94,8 +70,8 @@ class InvertFamilyInline(admin.TabularInline):
 
 @admin.register(InvertOrder)
 class InvertOrderAdmin(BaseAdmin):
-    list_display = ("name", "class_goi")
-    search_fields = ("name", "class_goi__invert_class__name")
+    list_display = ("name", "invert_class")
+    search_fields = ("name", "invert_class__name")
     inlines = [InvertFamilyInline]
 
 
@@ -124,8 +100,8 @@ class InvertSpeciesInline(admin.TabularInline):
 
 @admin.register(InvertGenus)
 class InvertGenusAdmin(BaseAdmin):
-    list_display = ("name", "family")
-    search_fields = ("name", "family__name")
+    list_display = ("name", "family", "group_of_interest")
+    search_fields = ("name", "family__name", "group_of_interest__name")
     inlines = [InvertSpeciesInline]
 
 
@@ -163,14 +139,12 @@ class BeltInvertAdmin(TransectMethodAdmin):
 
     def get_formsets_with_inlines(self, request, obj=None):
         qs = InvertAttribute.objects.select_related(
+            "invertgroupofinterest",
             "invertclass",
-            "invertclassgroupofinterest",
-            "invertclassgroupofinterest__invert_class",
-            "invertclassgroupofinterest__group_of_interest",
-            "invertorder",
-            "invertfamily",
-            "invertgenus",
-            "invertspecies",
+            "invertorder__invert_class",
+            "invertfamily__order",
+            "invertgenus__family",
+            "invertgenus__group_of_interest",
             "invertspecies__genus",
         )
         invert_attributes = sorted(qs, key=str)

--- a/src/api/migrations/0113_goi_schema_additions.py
+++ b/src/api/migrations/0113_goi_schema_additions.py
@@ -1,0 +1,61 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0112_bump_proposed_attribute_revisions"),
+    ]
+
+    operations = [
+        # 1. Add nullable group_of_interest FK on InvertGenus.
+        #    Populated in 0114; made non-nullable in 0115.
+        migrations.AddField(
+            model_name="invertgenus",
+            name="group_of_interest",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to="api.invertgroupofinterest",
+            ),
+        ),
+        # 2. Remove unique_invertorder_name_class_goi before the FK change and
+        #    InvertOrder de-duplication in 0114.
+        migrations.RemoveConstraint(
+            model_name="invertorder",
+            name="unique_invertorder_name_class_goi",
+        ),
+        # 3. Add nullable invert_class FK on InvertOrder.
+        #    Populated in 0114; made non-nullable in 0115.
+        migrations.AddField(
+            model_name="invertorder",
+            name="invert_class",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="orders",
+                to="api.invertclass",
+            ),
+        ),
+        # 4. Remove unique_invertfamily_name_order before InvertFamily de-duplication
+        #    in 0114 (two Muricidae rows temporarily share the same (name, order)
+        #    after InvertOrder de-duplication merges them under one parent).
+        migrations.RemoveConstraint(
+            model_name="invertfamily",
+            name="unique_invertfamily_name_order",
+        ),
+        # 5. Add nullable invertattribute_ptr on InvertGroupOfInterest to begin MTI
+        #    promotion. Populated in 0114; promoted to PK in 0115.
+        migrations.AddField(
+            model_name="invertgroupofinterest",
+            name="invertattribute_ptr",
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="api.invertattribute",
+            ),
+        ),
+    ]

--- a/src/api/migrations/0114_goi_data.py
+++ b/src/api/migrations/0114_goi_data.py
@@ -1,0 +1,105 @@
+from django.db import migrations
+
+SUPERUSER_APPROVED = 90
+
+
+def populate_genus_group_of_interest(apps, schema_editor):
+    """Walk genus → family → order → class_goi → group_of_interest and populate the new FK."""
+    InvertGenus = apps.get_model("api", "InvertGenus")
+    genera = list(InvertGenus.objects.select_related("family__order__class_goi__group_of_interest"))
+    for genus in genera:
+        genus.group_of_interest_id = genus.family.order.class_goi.group_of_interest_id
+    InvertGenus.objects.bulk_update(genera, ["group_of_interest_id"])
+
+
+def populate_order_invert_class(apps, schema_editor):
+    """Walk order → class_goi → invert_class and populate the new FK."""
+    InvertOrder = apps.get_model("api", "InvertOrder")
+    orders = list(InvertOrder.objects.select_related("class_goi__invert_class"))
+    for order in orders:
+        order.invert_class_id = order.class_goi.invert_class_id
+    InvertOrder.objects.bulk_update(orders, ["invert_class_id"])
+
+
+def promote_goi_to_invert_attribute(apps, schema_editor):
+    """Create an InvertAttribute row for each InvertGroupOfInterest using the same UUID.
+
+    By reusing the same UUID, any FK in InvertGenus.group_of_interest_id that was
+    populated in the previous step continues to resolve correctly after the PK swap
+    in migration 0115 — no FK value updates are needed.
+    """
+    InvertAttribute = apps.get_model("api", "InvertAttribute")
+    InvertGroupOfInterest = apps.get_model("api", "InvertGroupOfInterest")
+
+    gois = list(InvertGroupOfInterest.objects.all())
+    for goi in gois:
+        InvertAttribute.objects.create(id=goi.id, status=SUPERUSER_APPROVED)
+        goi.invertattribute_ptr_id = goi.id
+    InvertGroupOfInterest.objects.bulk_update(gois, ["invertattribute_ptr_id"])
+
+
+def deduplicate_invert_order(apps, schema_editor):
+    """Merge duplicate InvertOrder rows (same name, different class_goi) into one.
+
+    The canonical row is the one whose class_goi.group_of_interest.name sorts
+    alphabetically first, for determinism.  All InvertFamily rows pointing to
+    non-canonical orders are re-pointed to the canonical row before deletion.
+    """
+    InvertAttribute = apps.get_model("api", "InvertAttribute")
+    InvertOrder = apps.get_model("api", "InvertOrder")
+    InvertFamily = apps.get_model("api", "InvertFamily")
+
+    orders = list(
+        InvertOrder.objects.select_related("class_goi__group_of_interest").order_by("name")
+    )
+    by_name = {}
+    for order in orders:
+        by_name.setdefault(order.name, []).append(order)
+
+    for name, dups in by_name.items():
+        if len(dups) <= 1:
+            continue
+        canonical = min(dups, key=lambda o: o.class_goi.group_of_interest.name)
+        non_canonical_ids = [o.pk for o in dups if o.pk != canonical.pk]
+        InvertFamily.objects.filter(order_id__in=non_canonical_ids).update(order=canonical)
+        InvertAttribute.objects.filter(pk__in=non_canonical_ids).delete()
+
+
+def deduplicate_invert_family(apps, schema_editor):
+    """Merge duplicate InvertFamily rows (same name + order) created by order merge.
+
+    After order de-duplication both Muricidae rows share the same (name, order) pair.
+    The canonical row is chosen by lowest pk (alphabetical UUID sort).  All InvertGenus
+    rows pointing to non-canonical families are re-pointed before deletion.
+    """
+    InvertAttribute = apps.get_model("api", "InvertAttribute")
+    InvertFamily = apps.get_model("api", "InvertFamily")
+    InvertGenus = apps.get_model("api", "InvertGenus")
+
+    families = list(InvertFamily.objects.order_by("name", "order_id"))
+    by_key = {}
+    for family in families:
+        key = (family.name, str(family.order_id))
+        by_key.setdefault(key, []).append(family)
+
+    for key, dups in by_key.items():
+        if len(dups) <= 1:
+            continue
+        canonical = min(dups, key=lambda f: str(f.pk))
+        non_canonical_ids = [f.pk for f in dups if f.pk != canonical.pk]
+        InvertGenus.objects.filter(family_id__in=non_canonical_ids).update(family=canonical)
+        InvertAttribute.objects.filter(pk__in=non_canonical_ids).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0113_goi_schema_additions"),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_genus_group_of_interest, migrations.RunPython.noop),
+        migrations.RunPython(populate_order_invert_class, migrations.RunPython.noop),
+        migrations.RunPython(promote_goi_to_invert_attribute, migrations.RunPython.noop),
+        migrations.RunPython(deduplicate_invert_order, migrations.RunPython.noop),
+        migrations.RunPython(deduplicate_invert_family, migrations.RunPython.noop),
+    ]

--- a/src/api/migrations/0115_goi_schema_finalize.py
+++ b/src/api/migrations/0115_goi_schema_finalize.py
@@ -1,0 +1,138 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def delete_invert_class_group_of_interest(apps, schema_editor):
+    """Delete all InvertClassGroupOfInterest rows via their InvertAttribute parent.
+
+    Must run after RemoveField(invertorder, class_goi) so that the PROTECT FK from
+    InvertOrder no longer blocks deletion.
+    """
+    InvertAttribute = apps.get_model("api", "InvertAttribute")
+    InvertClassGroupOfInterest = apps.get_model("api", "InvertClassGroupOfInterest")
+    attr_ids = list(
+        InvertClassGroupOfInterest.objects.values_list("invertattribute_ptr_id", flat=True)
+    )
+    InvertAttribute.objects.filter(pk__in=attr_ids).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0114_goi_data"),
+    ]
+
+    operations = [
+        # 1. Make InvertGenus.group_of_interest non-nullable (all rows populated in 0114).
+        migrations.AlterField(
+            model_name="invertgenus",
+            name="group_of_interest",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                to="api.invertgroupofinterest",
+            ),
+        ),
+        # 2. Make InvertOrder.invert_class non-nullable (all rows populated in 0114).
+        migrations.AlterField(
+            model_name="invertorder",
+            name="invert_class",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="orders",
+                to="api.invertclass",
+            ),
+        ),
+        # 3. Remove the old class_goi FK from InvertOrder.
+        #    This unblocks deletion of InvertClassGroupOfInterest rows in step 4.
+        migrations.RemoveField(
+            model_name="invertorder",
+            name="class_goi",
+        ),
+        # 4. Delete InvertClassGroupOfInterest rows (and their InvertAttribute parents).
+        #    Safe now that no InvertOrder rows reference them.
+        migrations.RunPython(
+            delete_invert_class_group_of_interest,
+            migrations.RunPython.noop,
+        ),
+        # 5. Re-add unique constraint on InvertOrder(name, invert_class).
+        migrations.AddConstraint(
+            model_name="invertorder",
+            constraint=models.UniqueConstraint(
+                fields=["name", "invert_class"],
+                name="unique_invertorder_name_invert_class",
+            ),
+        ),
+        # 6. Re-add unique constraint on InvertFamily(name, order) — safe now that
+        #    Muricidae is no longer duplicated.
+        migrations.AddConstraint(
+            model_name="invertfamily",
+            constraint=models.UniqueConstraint(
+                fields=["name", "order"],
+                name="unique_invertfamily_name_order",
+            ),
+        ),
+        # 7. Promote invertattribute_ptr to PK on InvertGroupOfInterest.
+        #
+        #    Django cannot drop a primary key column directly, so this uses
+        #    SeparateDatabaseAndState:
+        #      - Database side: raw SQL to swap the PK and restore the FK from
+        #        invert_genus (which is cascade-dropped when id is dropped).
+        #      - State side: delete + recreate the model with the correct MTI bases
+        #        so future makemigrations detects no drift.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    -- Drop id column; CASCADE drops the old PK constraint and all FK
+                    -- constraints from other tables that reference invert_group_of_interest(id).
+                    ALTER TABLE invert_group_of_interest DROP COLUMN id CASCADE;
+
+                    -- Make invertattribute_ptr_id the new primary key.
+                    ALTER TABLE invert_group_of_interest
+                        ADD PRIMARY KEY (invertattribute_ptr_id);
+
+                    -- Restore the FK from invert_genus.group_of_interest_id.
+                    -- The UUID values are unchanged (same UUIDs used for both id and
+                    -- invertattribute_ptr_id in migration 0114), so no data updates needed.
+                    ALTER TABLE invert_genus
+                        ADD CONSTRAINT invert_genus_group_of_interest_id_fk
+                        FOREIGN KEY (group_of_interest_id)
+                        REFERENCES invert_group_of_interest (invertattribute_ptr_id);
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+            state_operations=[
+                # Recreate InvertGroupOfInterest as a proper InvertAttribute MTI child
+                # so that the migration state matches the model code.
+                migrations.DeleteModel(name="InvertGroupOfInterest"),
+                migrations.CreateModel(
+                    name="InvertGroupOfInterest",
+                    fields=[
+                        (
+                            "invertattribute_ptr",
+                            models.OneToOneField(
+                                auto_created=True,
+                                on_delete=django.db.models.deletion.CASCADE,
+                                parent_link=True,
+                                primary_key=True,
+                                serialize=False,
+                                to="api.invertattribute",
+                            ),
+                        ),
+                        ("name", models.CharField(max_length=100, unique=True)),
+                    ],
+                    options={
+                        "verbose_name": "macroinvertebrate group of interest",
+                        "verbose_name_plural": "macroinvertebrate groups of interest",
+                        "db_table": "invert_group_of_interest",
+                        "ordering": ("name",),
+                    },
+                    bases=("api.invertattribute",),
+                ),
+            ],
+        ),
+        # 8. Drop the now-empty invert_class_goi table.
+        migrations.DeleteModel(
+            name="InvertClassGroupOfInterest",
+        ),
+    ]

--- a/src/api/models/protocols/macroinvertebrate.py
+++ b/src/api/models/protocols/macroinvertebrate.py
@@ -56,19 +56,6 @@ class InvertSize(BaseModel):
         verbose_name_plural = _("macroinvertebrate sizes")
 
 
-class InvertGroupOfInterest(BaseChoiceModel):
-    name = models.CharField(max_length=100, unique=True)
-
-    def __str__(self):
-        return _("%s") % self.name
-
-    class Meta:
-        db_table = "invert_group_of_interest"
-        ordering = ("name",)
-        verbose_name = _("macroinvertebrate group of interest")
-        verbose_name_plural = _("macroinvertebrate groups of interest")
-
-
 class InvertHarvestType(BaseChoiceModel):
     name = models.CharField(max_length=100, unique=True)
 
@@ -83,8 +70,8 @@ class InvertHarvestType(BaseChoiceModel):
 
 
 class InvertAttribute(BaseAttributeModel):
+    GOI_RANK = "goi"
     CLASS_RANK = "class"
-    CLASS_GOI_RANK = "class_goi"
     ORDER_RANK = "order"
     FAMILY_RANK = "family"
     GENUS_RANK = "genus"
@@ -96,11 +83,8 @@ class InvertAttribute(BaseAttributeModel):
     def __str__(self):
         if hasattr(self, "invertclass"):
             return _("%s") % self.invertclass.name
-        elif hasattr(self, "invertclassgroupofinterest"):
-            return _("%s (%s)") % (
-                self.invertclassgroupofinterest.invert_class.name,
-                self.invertclassgroupofinterest.group_of_interest.name,
-            )
+        elif hasattr(self, "invertgroupofinterest"):
+            return self.invertgroupofinterest.name
         elif hasattr(self, "invertorder"):
             return _("%s") % self.invertorder.name
         elif hasattr(self, "invertfamily"):
@@ -115,8 +99,8 @@ class InvertAttribute(BaseAttributeModel):
     def taxonomic_rank(self):
         if hasattr(self, "invertclass"):
             return self.CLASS_RANK
-        elif hasattr(self, "invertclassgroupofinterest"):
-            return self.CLASS_GOI_RANK
+        elif hasattr(self, "invertgroupofinterest"):
+            return self.GOI_RANK
         elif hasattr(self, "invertorder"):
             return self.ORDER_RANK
         elif hasattr(self, "invertfamily"):
@@ -160,9 +144,21 @@ class InvertMaxLengthMixin:
         return self._max_length
 
 
+class InvertGroupOfInterest(InvertAttribute):
+    name = models.CharField(max_length=100, unique=True)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        db_table = "invert_group_of_interest"
+        ordering = ("name",)
+        verbose_name = _("macroinvertebrate group of interest")
+        verbose_name_plural = _("macroinvertebrate groups of interest")
+
+
 class InvertClass(InvertMaxLengthMixin, InvertAttribute):
-    # Path from InvertSpecies up through InvertClassGroupOfInterest to InvertClass.
-    _species_join_path = "genus__family__order__class_goi__invert_class"
+    _species_join_path = "genus__family__order__invert_class"
 
     name = models.CharField(max_length=100, unique=True)
 
@@ -176,40 +172,11 @@ class InvertClass(InvertMaxLengthMixin, InvertAttribute):
         verbose_name_plural = _("macroinvertebrate classes")
 
 
-class InvertClassGroupOfInterest(InvertMaxLengthMixin, InvertAttribute):
-    # Path from InvertSpecies up to InvertClassGroupOfInterest via InvertOrder.class_goi.
-    _species_join_path = "genus__family__order__class_goi"
-
-    invert_class = models.ForeignKey(
-        InvertClass, on_delete=models.PROTECT, related_name="class_gois"
-    )
-    group_of_interest = models.ForeignKey(
-        InvertGroupOfInterest, on_delete=models.PROTECT, related_name="class_gois"
-    )
-
-    def __str__(self):
-        return _("%s (%s)") % (self.invert_class.name, self.group_of_interest.name)
-
-    class Meta:
-        db_table = "invert_class_goi"
-        ordering = ("invert_class__name", "group_of_interest__name")
-        verbose_name = _("macroinvertebrate class / group of interest")
-        verbose_name_plural = _("macroinvertebrate class / groups of interest")
-        constraints = [
-            models.UniqueConstraint(
-                fields=["invert_class", "group_of_interest"],
-                name="unique_invert_class_goi",
-            )
-        ]
-
-
 class InvertOrder(InvertMaxLengthMixin, InvertAttribute):
     _species_join_path = "genus__family__order"
 
     name = models.CharField(max_length=100)
-    class_goi = models.ForeignKey(
-        InvertClassGroupOfInterest, on_delete=models.PROTECT, related_name="orders"
-    )
+    invert_class = models.ForeignKey(InvertClass, on_delete=models.PROTECT, related_name="orders")
 
     def __str__(self):
         return _("%s") % self.name
@@ -221,7 +188,7 @@ class InvertOrder(InvertMaxLengthMixin, InvertAttribute):
         verbose_name_plural = _("macroinvertebrate orders")
         constraints = [
             models.UniqueConstraint(
-                fields=["name", "class_goi"], name="unique_invertorder_name_class_goi"
+                fields=["name", "invert_class"], name="unique_invertorder_name_invert_class"
             )
         ]
 
@@ -250,6 +217,7 @@ class InvertGenus(InvertMaxLengthMixin, InvertAttribute):
 
     name = models.CharField(max_length=100)
     family = models.ForeignKey(InvertFamily, on_delete=models.PROTECT, related_name="genera")
+    group_of_interest = models.ForeignKey(InvertGroupOfInterest, on_delete=models.PROTECT)
 
     def __str__(self):
         return _("%s") % self.name

--- a/src/api/reports/attributes_report.py
+++ b/src/api/reports/attributes_report.py
@@ -277,12 +277,12 @@ def write_invert_species(wb):
         COLUMN_NAMES,
         *[
             [
-                sp.genus.family.order.class_goi.invert_class.name,
+                sp.genus.family.order.invert_class.name,
                 sp.genus.family.order.name,
                 sp.genus.family.name,
                 sp.genus.name,
                 sp.name,
-                sp.genus.family.order.class_goi.group_of_interest.name,
+                sp.genus.group_of_interest.name,
                 sp.max_length,
                 sp.max_length_type,
                 sp.max_length_source,
@@ -290,15 +290,14 @@ def write_invert_species(wb):
             ]
             for sp in InvertSpecies.objects.select_related(
                 "genus",
+                "genus__group_of_interest",
                 "genus__family",
                 "genus__family__order",
-                "genus__family__order__class_goi",
-                "genus__family__order__class_goi__invert_class",
-                "genus__family__order__class_goi__group_of_interest",
+                "genus__family__order__invert_class",
             )
             .filter(status=SUPERUSER_APPROVED)
             .order_by(
-                "genus__family__order__class_goi__invert_class__name",
+                "genus__family__order__invert_class__name",
                 "genus__family__order__name",
                 "genus__family__name",
                 "genus__name",

--- a/src/api/resources/choices.py
+++ b/src/api/resources/choices.py
@@ -52,7 +52,12 @@ class ChoiceViewSet(BaseChoiceApiViewSet):
         )
         invertsizebins = dict(data=InvertSizeBin.objects.choices(order_by="val"))
         invertsizebins["data"] = natsorted(invertsizebins["data"], key=itemgetter(*["name"]))
-        invertgroupsofinterest = dict(data=InvertGroupOfInterest.objects.choices(order_by="name"))
+        invertgroupsofinterest = dict(
+            data=[
+                {"id": goi.pk, "name": goi.name, "updated_on": goi.updated_on}
+                for goi in InvertGroupOfInterest.objects.order_by("name")
+            ]
+        )
         invertharvesttypes = dict(data=InvertHarvestType.objects.choices(order_by="name"))
         benthiclifehistories = dict(data=BenthicLifeHistory.objects.choices(order_by="name"))
         growthforms = dict(data=GrowthForm.objects.choices(order_by="name"))

--- a/src/api/resources/invert_attribute.py
+++ b/src/api/resources/invert_attribute.py
@@ -1,0 +1,117 @@
+from rest_framework import serializers
+
+from ..models import InvertAttribute
+from .base import BaseAPIFilterSet, BaseAPISerializer, BaseAttributeApiViewSet
+from .mixins import CreateOrUpdateSerializerMixin
+
+
+class InvertAttributeSerializer(CreateOrUpdateSerializerMixin, BaseAPISerializer):
+    status = serializers.ReadOnlyField()
+    taxonomic_rank = serializers.ReadOnlyField()
+    name = serializers.SerializerMethodField()
+    max_length = serializers.SerializerMethodField()
+    parent = serializers.SerializerMethodField()
+    class_goi = serializers.SerializerMethodField()
+    max_length_type = serializers.SerializerMethodField()
+    max_length_source = serializers.SerializerMethodField()
+    max_length_url = serializers.SerializerMethodField()
+    notes = serializers.SerializerMethodField()
+
+    class Meta:
+        model = InvertAttribute
+        exclude = []
+
+    def get_name(self, obj):
+        return str(obj)
+
+    def _taxon(self, obj):
+        for attr in (
+            "invertspecies",
+            "invertgenus",
+            "invertfamily",
+            "invertorder",
+            "invertclassgroupofinterest",
+        ):
+            taxon = getattr(obj, attr, None)
+            if taxon is not None:
+                return taxon
+        return None
+
+    def get_max_length(self, obj):
+        taxon = self._taxon(obj)
+        return taxon.max_length if taxon is not None else None
+
+    def get_parent(self, obj):
+        species = getattr(obj, "invertspecies", None)
+        if species is not None:
+            return species.genus_id
+        genus = getattr(obj, "invertgenus", None)
+        if genus is not None:
+            return genus.family_id
+        family = getattr(obj, "invertfamily", None)
+        if family is not None:
+            return family.order_id
+        order = getattr(obj, "invertorder", None)
+        if order is not None:
+            return order.class_goi_id
+        return None
+
+    def get_class_goi(self, obj):
+        species = getattr(obj, "invertspecies", None)
+        if species is not None:
+            return species.genus.family.order.class_goi_id
+        genus = getattr(obj, "invertgenus", None)
+        if genus is not None:
+            return genus.family.order.class_goi_id
+        family = getattr(obj, "invertfamily", None)
+        if family is not None:
+            return family.order.class_goi_id
+        order = getattr(obj, "invertorder", None)
+        if order is not None:
+            return order.class_goi_id
+        class_goi = getattr(obj, "invertclassgroupofinterest", None)
+        if class_goi is not None:
+            return class_goi.pk
+        return None
+
+    def get_max_length_type(self, obj):
+        species = getattr(obj, "invertspecies", None)
+        return species.max_length_type if species is not None else None
+
+    def get_max_length_source(self, obj):
+        species = getattr(obj, "invertspecies", None)
+        return species.max_length_source if species is not None else None
+
+    def get_max_length_url(self, obj):
+        species = getattr(obj, "invertspecies", None)
+        return species.max_length_url if species is not None else None
+
+    def get_notes(self, obj):
+        species = getattr(obj, "invertspecies", None)
+        return species.notes if species is not None else None
+
+
+class InvertAttributeFilterSet(BaseAPIFilterSet):
+    class Meta:
+        model = InvertAttribute
+        fields = []
+
+
+class InvertAttributeViewSet(BaseAttributeApiViewSet):
+    serializer_class = InvertAttributeSerializer
+    # Exclude internal InvertClass nodes — user-visible hierarchy is
+    # ClassGroupOfInterest → Order → Family → Genus → Species.
+    # select_related pre-fetches full chain to class_goi for the class_goi field.
+    queryset = (
+        InvertAttribute.objects.select_related(
+            "invertclassgroupofinterest__invert_class",
+            "invertclassgroupofinterest__group_of_interest",
+            "invertorder__class_goi",
+            "invertfamily__order__class_goi",
+            "invertgenus__family__order__class_goi",
+            "invertspecies__genus__family__order__class_goi",
+        )
+        .filter(invertclass__isnull=True)
+        .order_by("id")
+    )
+    filterset_class = InvertAttributeFilterSet

--- a/src/api/resources/invert_attribute.py
+++ b/src/api/resources/invert_attribute.py
@@ -11,7 +11,7 @@ class InvertAttributeSerializer(CreateOrUpdateSerializerMixin, BaseAPISerializer
     name = serializers.SerializerMethodField()
     max_length = serializers.SerializerMethodField()
     parent = serializers.SerializerMethodField()
-    class_goi = serializers.SerializerMethodField()
+    group_of_interest = serializers.SerializerMethodField()
     max_length_type = serializers.SerializerMethodField()
     max_length_source = serializers.SerializerMethodField()
     max_length_url = serializers.SerializerMethodField()
@@ -30,7 +30,7 @@ class InvertAttributeSerializer(CreateOrUpdateSerializerMixin, BaseAPISerializer
             "invertgenus",
             "invertfamily",
             "invertorder",
-            "invertclassgroupofinterest",
+            "invertclass",
         ):
             taxon = getattr(obj, attr, None)
             if taxon is not None:
@@ -53,25 +53,22 @@ class InvertAttributeSerializer(CreateOrUpdateSerializerMixin, BaseAPISerializer
             return family.order_id
         order = getattr(obj, "invertorder", None)
         if order is not None:
-            return order.class_goi_id
+            return order.invert_class_id
         return None
 
-    def get_class_goi(self, obj):
+    def get_group_of_interest(self, obj):
+        goi = getattr(obj, "invertgroupofinterest", None)
+        if goi is not None:
+            return obj.pk
+
         species = getattr(obj, "invertspecies", None)
         if species is not None:
-            return species.genus.family.order.class_goi_id
+            return species.genus.group_of_interest_id
+
         genus = getattr(obj, "invertgenus", None)
         if genus is not None:
-            return genus.family.order.class_goi_id
-        family = getattr(obj, "invertfamily", None)
-        if family is not None:
-            return family.order.class_goi_id
-        order = getattr(obj, "invertorder", None)
-        if order is not None:
-            return order.class_goi_id
-        class_goi = getattr(obj, "invertclassgroupofinterest", None)
-        if class_goi is not None:
-            return class_goi.pk
+            return genus.group_of_interest_id
+
         return None
 
     def get_max_length_type(self, obj):
@@ -99,19 +96,14 @@ class InvertAttributeFilterSet(BaseAPIFilterSet):
 
 class InvertAttributeViewSet(BaseAttributeApiViewSet):
     serializer_class = InvertAttributeSerializer
-    # Exclude internal InvertClass nodes — user-visible hierarchy is
-    # ClassGroupOfInterest → Order → Family → Genus → Species.
-    # select_related pre-fetches full chain to class_goi for the class_goi field.
-    queryset = (
-        InvertAttribute.objects.select_related(
-            "invertclassgroupofinterest__invert_class",
-            "invertclassgroupofinterest__group_of_interest",
-            "invertorder__class_goi",
-            "invertfamily__order__class_goi",
-            "invertgenus__family__order__class_goi",
-            "invertspecies__genus__family__order__class_goi",
-        )
-        .filter(invertclass__isnull=True)
-        .order_by("id")
-    )
+    queryset = InvertAttribute.objects.select_related(
+        "invertgroupofinterest",
+        "invertclass",
+        "invertorder__invert_class",
+        "invertfamily__order__invert_class",
+        "invertgenus__family__order__invert_class",
+        "invertgenus__group_of_interest",
+        "invertspecies__genus__family__order__invert_class",
+        "invertspecies__genus__group_of_interest",
+    ).order_by("id")
     filterset_class = InvertAttributeFilterSet

--- a/src/api/resources/invert_belt_transect.py
+++ b/src/api/resources/invert_belt_transect.py
@@ -1,0 +1,50 @@
+import django_filters
+
+from ..models import InvertBeltTransect
+from .base import BaseProjectApiViewSet, ModelValReadOnlyField
+from .sample_units_base import (
+    SampleUnitExtendedSerializer,
+    SampleUnitFilterSet,
+    SampleUnitSerializer,
+)
+
+
+class InvertBeltTransectExtendedSerializer(SampleUnitExtendedSerializer):
+    width = ModelValReadOnlyField()
+
+    class Meta:
+        model = InvertBeltTransect
+        exclude = []
+
+
+class InvertBeltTransectSerializer(SampleUnitSerializer):
+    class Meta:
+        model = InvertBeltTransect
+        exclude = []
+        extra_kwargs = {
+            "number": {"error_messages": {"null": "Transect number is required"}},
+            "len_surveyed": {"error_messages": {"null": "Transect length surveyed is required"}},
+            "width": {"error_messages": {"null": "Width is required"}},
+        }
+        extra_kwargs.update(SampleUnitSerializer.extra_kwargs)
+
+
+class InvertBeltTransectFilterSet(SampleUnitFilterSet):
+    len_surveyed = django_filters.RangeFilter(field_name="len_surveyed")
+
+    class Meta:
+        model = InvertBeltTransect
+        fields = [
+            "beltinvert_method",
+            "sample_event",
+            "len_surveyed",
+            "width",
+            "size_bin",
+            "depth",
+        ] + SampleUnitFilterSet.fields
+
+
+class InvertBeltTransectViewSet(BaseProjectApiViewSet):
+    serializer_class = InvertBeltTransectSerializer
+    queryset = InvertBeltTransect.objects.order_by("id")
+    filterset_class = InvertBeltTransectFilterSet

--- a/src/api/resources/invert_belt_transect.py
+++ b/src/api/resources/invert_belt_transect.py
@@ -22,11 +22,11 @@ class InvertBeltTransectSerializer(SampleUnitSerializer):
         model = InvertBeltTransect
         exclude = []
         extra_kwargs = {
+            **SampleUnitSerializer.extra_kwargs,
             "number": {"error_messages": {"null": "Transect number is required"}},
             "len_surveyed": {"error_messages": {"null": "Transect length surveyed is required"}},
             "width": {"error_messages": {"null": "Width is required"}},
         }
-        extra_kwargs.update(SampleUnitSerializer.extra_kwargs)
 
 
 class InvertBeltTransectFilterSet(SampleUnitFilterSet):

--- a/src/api/resources/sampleunitmethods/sample_unit_methods.py
+++ b/src/api/resources/sampleunitmethods/sample_unit_methods.py
@@ -47,6 +47,8 @@ class SearchNonFieldFilter(django_filters.Filter):
         "habitatcomplexity__observers__profile__last_name",
         "bleachingquadratcollection__observers__profile__first_name",
         "bleachingquadratcollection__observers__profile__last_name",
+        "beltinvert__observers__profile__first_name",
+        "beltinvert__observers__profile__last_name",
     ]
 
     def filter(self, qs, value):

--- a/src/api/resources/sync/views.py
+++ b/src/api/resources/sync/views.py
@@ -17,6 +17,7 @@ from api.resources import (
     fish_genus,
     fish_grouping,
     fish_species,
+    invert_attribute,
     pmanagement,
     project,
     project_profile,
@@ -41,6 +42,7 @@ FISH_FAMILIES_SOURCE_TYPE = "fish_families"
 FISH_GENERA_SOURCE_TYPE = "fish_genera"
 FISH_GROUPINGS_SOURCE_TYPE = "fish_groupings"
 FISH_SPECIES_SOURCE_TYPE = "fish_species"
+INVERT_ATTRIBUTES_SOURCE_TYPE = "invert_attributes"
 CHOICES_SOURCE_TYPE = "choices"
 
 CACHEABLE_SOURCE_TYPES = (
@@ -49,6 +51,7 @@ CACHEABLE_SOURCE_TYPES = (
     FISH_GENERA_SOURCE_TYPE,
     FISH_GROUPINGS_SOURCE_TYPE,
     FISH_SPECIES_SOURCE_TYPE,
+    INVERT_ATTRIBUTES_SOURCE_TYPE,
 )
 
 project_sources = {
@@ -104,6 +107,12 @@ non_project_sources = {
         "view": fish_species.FishSpeciesViewSet,
         "required_filters": NO_FILTERS,
         "read_only": False,
+    },
+    INVERT_ATTRIBUTES_SOURCE_TYPE: {
+        "view": invert_attribute.InvertAttributeViewSet,
+        "required_filters": NO_FILTERS,
+        "read_only": False,
+        "visibility_filtered": True,
     },
     CHOICES_SOURCE_TYPE: {
         "view": choices.ChoiceViewSet,

--- a/src/api/tests/fixtures/__init__.py
+++ b/src/api/tests/fixtures/__init__.py
@@ -10,6 +10,7 @@ from .collect_records import *  # noqa: F403
 from .covariates import *  # noqa: F403
 from .fish_attributes import *  # noqa: F403
 from .habitat_complexity import *  # noqa: F403
+from .macroinvertebrate import *  # noqa: F403
 from .mock_http_server import mock_covariate_server  # noqa: F401
 from .notifications import *  # noqa: F403
 from .projects import *  # noqa: F403

--- a/src/api/tests/fixtures/macroinvertebrate.py
+++ b/src/api/tests/fixtures/macroinvertebrate.py
@@ -33,6 +33,11 @@ def invert_size_bin_1(db):
 
 
 @pytest.fixture
+def invert_size_bin_2(db):
+    return InvertSizeBin.objects.create(val="2")
+
+
+@pytest.fixture
 def invert_group_of_interest_1(db):
     return InvertGroupOfInterest.objects.create(name="Sea urchins")
 

--- a/src/api/tests/fixtures/macroinvertebrate.py
+++ b/src/api/tests/fixtures/macroinvertebrate.py
@@ -1,0 +1,131 @@
+import pytest
+
+from api.models import (
+    SUPERUSER_APPROVED,
+    BeltInvert,
+    InvertBeltTransect,
+    InvertBeltTransectWidth,
+    InvertClass,
+    InvertClassGroupOfInterest,
+    InvertFamily,
+    InvertGenus,
+    InvertGroupOfInterest,
+    InvertOrder,
+    InvertSizeBin,
+    InvertSpecies,
+    Observer,
+)
+
+
+@pytest.fixture
+def invert_belt_transect_width_1m(db):
+    return InvertBeltTransectWidth.objects.create(val=1, name="1m")
+
+
+@pytest.fixture
+def invert_belt_transect_width_2m(db):
+    return InvertBeltTransectWidth.objects.create(val=2, name="2m")
+
+
+@pytest.fixture
+def invert_size_bin_1(db):
+    return InvertSizeBin.objects.create(val="1")
+
+
+@pytest.fixture
+def invert_group_of_interest_1(db):
+    return InvertGroupOfInterest.objects.create(name="Sea urchins")
+
+
+@pytest.fixture
+def invert_class_1(db):
+    return InvertClass.objects.create(name="Echinoidea")
+
+
+@pytest.fixture
+def invert_class_goi_1(db, invert_class_1, invert_group_of_interest_1):
+    return InvertClassGroupOfInterest.objects.create(
+        invert_class=invert_class_1,
+        group_of_interest=invert_group_of_interest_1,
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
+def invert_order_1(db, invert_class_goi_1):
+    return InvertOrder.objects.create(
+        name="Camarodonta",
+        class_goi=invert_class_goi_1,
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
+def invert_family_1(db, invert_order_1):
+    return InvertFamily.objects.create(
+        name="Strongylocentrotidae",
+        order=invert_order_1,
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
+def invert_genus_1(db, invert_family_1):
+    return InvertGenus.objects.create(
+        name="Strongylocentrotus",
+        family=invert_family_1,
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
+def invert_species_1(db, invert_genus_1):
+    return InvertSpecies.objects.create(
+        name="purpuratus",
+        genus=invert_genus_1,
+        max_length=8,
+        max_length_type="test diameter",
+        notes="Purple sea urchin",
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
+def all_test_invert_attributes(
+    invert_class_goi_1, invert_order_1, invert_family_1, invert_genus_1, invert_species_1
+):
+    return [invert_class_goi_1, invert_order_1, invert_family_1, invert_genus_1, invert_species_1]
+
+
+@pytest.fixture
+def invert_belt_transect1(
+    db,
+    sample_event1,
+    current1,
+    reef_slope1,
+    relative_depth1,
+    tide1,
+    visibility1,
+    invert_belt_transect_width_1m,
+    invert_size_bin_1,
+):
+    return InvertBeltTransect.objects.create(
+        sample_event=sample_event1,
+        current=current1,
+        reef_slope=reef_slope1,
+        relative_depth=relative_depth1,
+        tide=tide1,
+        visibility=visibility1,
+        width=invert_belt_transect_width_1m,
+        size_bin=invert_size_bin_1,
+        depth=5,
+        len_surveyed=50,
+        number=1,
+    )
+
+
+@pytest.fixture
+def belt_invert1(db, invert_belt_transect1, profile1, project_profile1):
+    beltinvert = BeltInvert.objects.create(transect=invert_belt_transect1)
+    Observer.objects.create(transectmethod=beltinvert, profile=profile1, rank=1)
+    return beltinvert

--- a/src/api/tests/fixtures/macroinvertebrate.py
+++ b/src/api/tests/fixtures/macroinvertebrate.py
@@ -6,7 +6,6 @@ from api.models import (
     InvertBeltTransect,
     InvertBeltTransectWidth,
     InvertClass,
-    InvertClassGroupOfInterest,
     InvertFamily,
     InvertGenus,
     InvertGroupOfInterest,
@@ -39,28 +38,19 @@ def invert_size_bin_2(db):
 
 @pytest.fixture
 def invert_group_of_interest_1(db):
-    return InvertGroupOfInterest.objects.create(name="Sea urchins")
+    return InvertGroupOfInterest.objects.create(name="Sea urchins", status=SUPERUSER_APPROVED)
 
 
 @pytest.fixture
 def invert_class_1(db):
-    return InvertClass.objects.create(name="Echinoidea")
+    return InvertClass.objects.create(name="Echinoidea", status=SUPERUSER_APPROVED)
 
 
 @pytest.fixture
-def invert_class_goi_1(db, invert_class_1, invert_group_of_interest_1):
-    return InvertClassGroupOfInterest.objects.create(
-        invert_class=invert_class_1,
-        group_of_interest=invert_group_of_interest_1,
-        status=SUPERUSER_APPROVED,
-    )
-
-
-@pytest.fixture
-def invert_order_1(db, invert_class_goi_1):
+def invert_order_1(db, invert_class_1):
     return InvertOrder.objects.create(
         name="Camarodonta",
-        class_goi=invert_class_goi_1,
+        invert_class=invert_class_1,
         status=SUPERUSER_APPROVED,
     )
 
@@ -75,10 +65,11 @@ def invert_family_1(db, invert_order_1):
 
 
 @pytest.fixture
-def invert_genus_1(db, invert_family_1):
+def invert_genus_1(db, invert_family_1, invert_group_of_interest_1):
     return InvertGenus.objects.create(
         name="Strongylocentrotus",
         family=invert_family_1,
+        group_of_interest=invert_group_of_interest_1,
         status=SUPERUSER_APPROVED,
     )
 
@@ -96,10 +87,29 @@ def invert_species_1(db, invert_genus_1):
 
 
 @pytest.fixture
+def invert_goi_attribute_1(db, invert_group_of_interest_1):
+    # InvertGroupOfInterest is now an InvertAttribute subclass; the fixture
+    # returns the GoI record, which IS the attribute.
+    return invert_group_of_interest_1
+
+
+@pytest.fixture
 def all_test_invert_attributes(
-    invert_class_goi_1, invert_order_1, invert_family_1, invert_genus_1, invert_species_1
+    invert_goi_attribute_1,
+    invert_class_1,
+    invert_order_1,
+    invert_family_1,
+    invert_genus_1,
+    invert_species_1,
 ):
-    return [invert_class_goi_1, invert_order_1, invert_family_1, invert_genus_1, invert_species_1]
+    return [
+        invert_goi_attribute_1,
+        invert_class_1,
+        invert_order_1,
+        invert_family_1,
+        invert_genus_1,
+        invert_species_1,
+    ]
 
 
 @pytest.fixture

--- a/src/api/tests/test_invert_attributes.py
+++ b/src/api/tests/test_invert_attributes.py
@@ -137,6 +137,73 @@ def test_invert_belt_transect_delete(db_setup, api_client1, project1, invert_bel
     assert not InvertBeltTransect.objects.filter(pk=pk).exists()
 
 
+def test_invertbelttransect_not_accessible_cross_project(
+    db_setup, api_client3, project1, invert_belt_transect1
+):
+    """User with no membership in project1 cannot read project1's invertbelttransects."""
+    response = api_client3.get(f"/v1/projects/{project1.pk}/invertbelttransects/", format="json")
+    assert response.status_code == 403
+
+
+def test_invertbelttransect_filter_len_surveyed(
+    db_setup, api_client1, project1, invert_belt_transect1
+):
+    """len_surveyed RangeFilter includes and excludes the transect correctly."""
+    url = f"/v1/projects/{project1.pk}/invertbelttransects/"
+    resp = api_client1.get(url, {"len_surveyed_min": 50}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+    resp = api_client1.get(url, {"len_surveyed_min": 100}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_invertbelttransect_filter_depth(db_setup, api_client1, project1, invert_belt_transect1):
+    """depth RangeFilter includes and excludes the transect correctly."""
+    url = f"/v1/projects/{project1.pk}/invertbelttransects/"
+    resp = api_client1.get(url, {"depth_max": 5}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+    resp = api_client1.get(url, {"depth_max": 1}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_invertbelttransect_filter_width(
+    db_setup,
+    api_client1,
+    project1,
+    invert_belt_transect1,
+    invert_belt_transect_width_1m,
+    invert_belt_transect_width_2m,
+):
+    """width filter matches the assigned width and excludes a different one."""
+    url = f"/v1/projects/{project1.pk}/invertbelttransects/"
+    resp = api_client1.get(url, {"width": str(invert_belt_transect_width_1m.pk)}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+    resp = api_client1.get(url, {"width": str(invert_belt_transect_width_2m.pk)}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_invertbelttransect_filter_size_bin(
+    db_setup, api_client1, project1, invert_belt_transect1, invert_size_bin_1, invert_size_bin_2
+):
+    """size_bin filter matches the assigned bin and excludes a different one."""
+    url = f"/v1/projects/{project1.pk}/invertbelttransects/"
+    resp = api_client1.get(url, {"size_bin": str(invert_size_bin_1.pk)}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+    resp = api_client1.get(url, {"size_bin": str(invert_size_bin_2.pk)}, format="json")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
 def test_sample_unit_method_search_fields_include_beltinvert():
     """SearchNonFieldFilter.SEARCH_FIELDS includes beltinvert observer name paths."""
     from api.resources.sampleunitmethods.sample_unit_methods import SearchNonFieldFilter

--- a/src/api/tests/test_invert_attributes.py
+++ b/src/api/tests/test_invert_attributes.py
@@ -1,0 +1,146 @@
+from api.models import InvertBeltTransect
+
+
+def test_list_invert_attributes_returns_user_visible_hierarchy(
+    db_setup, api_client1, all_test_invert_attributes
+):
+    """GET /v1/invertattributes/ returns ClassGOI, Order, Family, Genus, Species — not InvertClass."""
+    response = api_client1.get("/v1/invertattributes/", format="json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 5  # ClassGOI + Order + Family + Genus + Species
+
+    ranks = {rec["taxonomic_rank"] for rec in data["results"]}
+    assert "class" not in ranks
+    assert ranks == {"class_goi", "order", "family", "genus", "species"}
+
+
+def test_invert_attribute_species_fields(
+    db_setup, api_client1, all_test_invert_attributes, invert_species_1
+):
+    """Species nodes include max_length, max_length_type, notes; others return None."""
+    response = api_client1.get("/v1/invertattributes/", format="json")
+    data = response.json()
+
+    species_rec = next(r for r in data["results"] if r["taxonomic_rank"] == "species")
+    assert float(species_rec["max_length"]) == float(invert_species_1.max_length)
+    assert species_rec["max_length_type"] == invert_species_1.max_length_type
+    assert species_rec["notes"] == invert_species_1.notes
+
+    non_species = [r for r in data["results"] if r["taxonomic_rank"] != "species"]
+    for rec in non_species:
+        assert rec["max_length_type"] is None
+        assert rec["max_length_source"] is None
+        assert rec["notes"] is None
+
+
+def test_invert_attribute_class_goi(
+    db_setup,
+    api_client1,
+    all_test_invert_attributes,
+    invert_class_goi_1,
+):
+    """class_goi is the InvertClassGroupOfInterest pk for every node in the hierarchy."""
+    response = api_client1.get("/v1/invertattributes/", format="json")
+    data = response.json()
+    for rec in data["results"]:
+        assert str(rec["class_goi"]) == str(
+            invert_class_goi_1.pk
+        ), f"{rec['taxonomic_rank']} node has wrong class_goi"
+
+
+def test_invert_attribute_parent_chain(
+    db_setup,
+    api_client1,
+    all_test_invert_attributes,
+    invert_class_goi_1,
+    invert_order_1,
+    invert_family_1,
+    invert_genus_1,
+    invert_species_1,
+):
+    """parent field encodes the correct FK for each level; ClassGOI has no parent."""
+    response = api_client1.get("/v1/invertattributes/", format="json")
+    data = response.json()
+    by_rank = {r["taxonomic_rank"]: r for r in data["results"]}
+
+    assert by_rank["class_goi"]["parent"] is None
+    assert str(by_rank["order"]["parent"]) == str(invert_class_goi_1.pk)
+    assert str(by_rank["family"]["parent"]) == str(invert_order_1.pk)
+    assert str(by_rank["genus"]["parent"]) == str(invert_family_1.pk)
+    assert str(by_rank["species"]["parent"]) == str(invert_genus_1.pk)
+
+
+def test_invert_attribute_detail(db_setup, api_client1, invert_species_1):
+    """GET /v1/invertattributes/{id}/ returns the correct record."""
+    response = api_client1.get(f"/v1/invertattributes/{invert_species_1.pk}/", format="json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["taxonomic_rank"] == "species"
+    assert float(data["max_length"]) == float(invert_species_1.max_length)
+
+
+def test_invert_belt_transect_list(db_setup, api_client1, project1, invert_belt_transect1):
+    """GET /v1/projects/{id}/invertbelttransects/ lists transects for the project."""
+    response = api_client1.get(f"/v1/projects/{project1.pk}/invertbelttransects/", format="json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert str(data["results"][0]["id"]) == str(invert_belt_transect1.pk)
+
+
+def test_invert_belt_transect_create(
+    db_setup, api_client1, project1, sample_event1, invert_belt_transect_width_1m, invert_size_bin_1
+):
+    """POST creates a new InvertBeltTransect."""
+    payload = {
+        "sample_event": str(sample_event1.pk),
+        "width": str(invert_belt_transect_width_1m.pk),
+        "size_bin": str(invert_size_bin_1.pk),
+        "depth": 10,
+        "len_surveyed": 25,
+        "number": 2,
+        "label": "",
+    }
+    response = api_client1.post(
+        f"/v1/projects/{project1.pk}/invertbelttransects/",
+        data=payload,
+        format="json",
+    )
+    assert response.status_code == 201
+    assert InvertBeltTransect.objects.filter(number=2).exists()
+
+
+def test_invert_belt_transect_retrieve(
+    db_setup, api_client1, project1, invert_belt_transect1, invert_belt_transect_width_1m
+):
+    """GET /v1/projects/{id}/invertbelttransects/{id}/ returns the correct record with all fields."""
+    response = api_client1.get(
+        f"/v1/projects/{project1.pk}/invertbelttransects/{invert_belt_transect1.pk}/",
+        format="json",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert str(data["id"]) == str(invert_belt_transect1.pk)
+    assert str(data["width"]) == str(invert_belt_transect_width_1m.pk)
+    assert data["number"] == 1
+
+
+def test_invert_belt_transect_delete(db_setup, api_client1, project1, invert_belt_transect1):
+    """DELETE removes the InvertBeltTransect."""
+    pk = invert_belt_transect1.pk
+    response = api_client1.delete(
+        f"/v1/projects/{project1.pk}/invertbelttransects/{pk}/",
+        format="json",
+    )
+    assert response.status_code == 204
+    assert not InvertBeltTransect.objects.filter(pk=pk).exists()
+
+
+def test_sample_unit_method_search_fields_include_beltinvert():
+    """SearchNonFieldFilter.SEARCH_FIELDS includes beltinvert observer name paths."""
+    from api.resources.sampleunitmethods.sample_unit_methods import SearchNonFieldFilter
+
+    fields = SearchNonFieldFilter.SEARCH_FIELDS
+    assert "beltinvert__observers__profile__first_name" in fields
+    assert "beltinvert__observers__profile__last_name" in fields

--- a/src/api/tests/test_invert_attributes.py
+++ b/src/api/tests/test_invert_attributes.py
@@ -4,15 +4,15 @@ from api.models import InvertBeltTransect
 def test_list_invert_attributes_returns_user_visible_hierarchy(
     db_setup, api_client1, all_test_invert_attributes
 ):
-    """GET /v1/invertattributes/ returns ClassGOI, Order, Family, Genus, Species — not InvertClass."""
+    """GET /v1/invertattributes/ returns GoI, Class, Order, Family, Genus, Species."""
     response = api_client1.get("/v1/invertattributes/", format="json")
     assert response.status_code == 200
     data = response.json()
-    assert data["count"] == 5  # ClassGOI + Order + Family + Genus + Species
+    assert data["count"] == 6  # GoI + Class + Order + Family + Genus + Species
 
     ranks = {rec["taxonomic_rank"] for rec in data["results"]}
-    assert "class" not in ranks
-    assert ranks == {"class_goi", "order", "family", "genus", "species"}
+    assert "class_goi" not in ranks
+    assert ranks == {"goi", "class", "order", "family", "genus", "species"}
 
 
 def test_invert_attribute_species_fields(
@@ -34,38 +34,39 @@ def test_invert_attribute_species_fields(
         assert rec["notes"] is None
 
 
-def test_invert_attribute_class_goi(
-    db_setup,
-    api_client1,
-    all_test_invert_attributes,
-    invert_class_goi_1,
+def test_invert_attribute_group_of_interest(
+    db_setup, api_client1, all_test_invert_attributes, invert_group_of_interest_1
 ):
-    """class_goi is the InvertClassGroupOfInterest pk for every node in the hierarchy."""
+    """genus and species return group_of_interest; class/order/family return None; goi returns itself."""
     response = api_client1.get("/v1/invertattributes/", format="json")
     data = response.json()
-    for rec in data["results"]:
-        assert str(rec["class_goi"]) == str(
-            invert_class_goi_1.pk
-        ), f"{rec['taxonomic_rank']} node has wrong class_goi"
+    by_rank = {r["taxonomic_rank"]: r for r in data["results"]}
+
+    assert str(by_rank["genus"]["group_of_interest"]) == str(invert_group_of_interest_1.pk)
+    assert str(by_rank["species"]["group_of_interest"]) == str(invert_group_of_interest_1.pk)
+    assert str(by_rank["goi"]["group_of_interest"]) == str(invert_group_of_interest_1.pk)
+    for rank in ("class", "order", "family"):
+        assert by_rank[rank]["group_of_interest"] is None
 
 
 def test_invert_attribute_parent_chain(
     db_setup,
     api_client1,
     all_test_invert_attributes,
-    invert_class_goi_1,
+    invert_class_1,
     invert_order_1,
     invert_family_1,
     invert_genus_1,
     invert_species_1,
 ):
-    """parent field encodes the correct FK for each level; ClassGOI has no parent."""
+    """parent field encodes the correct FK for each level; GoI and Class have no parent."""
     response = api_client1.get("/v1/invertattributes/", format="json")
     data = response.json()
     by_rank = {r["taxonomic_rank"]: r for r in data["results"]}
 
-    assert by_rank["class_goi"]["parent"] is None
-    assert str(by_rank["order"]["parent"]) == str(invert_class_goi_1.pk)
+    assert by_rank["goi"]["parent"] is None
+    assert by_rank["class"]["parent"] is None
+    assert str(by_rank["order"]["parent"]) == str(invert_class_1.pk)
     assert str(by_rank["family"]["parent"]) == str(invert_order_1.pk)
     assert str(by_rank["genus"]["parent"]) == str(invert_family_1.pk)
     assert str(by_rank["species"]["parent"]) == str(invert_genus_1.pk)
@@ -78,6 +79,18 @@ def test_invert_attribute_detail(db_setup, api_client1, invert_species_1):
     data = response.json()
     assert data["taxonomic_rank"] == "species"
     assert float(data["max_length"]) == float(invert_species_1.max_length)
+
+
+def test_invert_goi_attribute_detail(db_setup, api_client1, invert_group_of_interest_1):
+    """GET /v1/invertattributes/{id}/ works for a GoI node."""
+    response = api_client1.get(
+        f"/v1/invertattributes/{invert_group_of_interest_1.pk}/", format="json"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["taxonomic_rank"] == "goi"
+    assert data["name"] == invert_group_of_interest_1.name
+    assert str(data["group_of_interest"]) == str(invert_group_of_interest_1.pk)
 
 
 def test_invert_belt_transect_list(db_setup, api_client1, project1, invert_belt_transect1):

--- a/src/api/tests/test_invert_attributes.py
+++ b/src/api/tests/test_invert_attributes.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from api.models import InvertBeltTransect
 
 
@@ -23,7 +25,7 @@ def test_invert_attribute_species_fields(
     data = response.json()
 
     species_rec = next(r for r in data["results"] if r["taxonomic_rank"] == "species")
-    assert float(species_rec["max_length"]) == float(invert_species_1.max_length)
+    assert Decimal(str(species_rec["max_length"])) == Decimal(str(invert_species_1.max_length))
     assert species_rec["max_length_type"] == invert_species_1.max_length_type
     assert species_rec["notes"] == invert_species_1.notes
 
@@ -78,7 +80,7 @@ def test_invert_attribute_detail(db_setup, api_client1, invert_species_1):
     assert response.status_code == 200
     data = response.json()
     assert data["taxonomic_rank"] == "species"
-    assert float(data["max_length"]) == float(invert_species_1.max_length)
+    assert Decimal(str(data["max_length"])) == Decimal(str(invert_species_1.max_length))
 
 
 def test_invert_goi_attribute_detail(db_setup, api_client1, invert_group_of_interest_1):

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -20,6 +20,8 @@ from .resources.gfcr import IndicatorSetViewSet
 from .resources.health import health
 from .resources.images import AllImagesViewSet
 from .resources.ingest_schema import ingest_schema_csv
+from .resources.invert_attribute import InvertAttributeViewSet
+from .resources.invert_belt_transect import InvertBeltTransectViewSet
 from .resources.management import ManagementViewSet
 from .resources.me import MeViewSet
 from .resources.notification import NotificationViewSet
@@ -95,6 +97,7 @@ router.register(r"notifications", NotificationViewSet, "notification")
 
 # observation attributes
 router.register(r"benthicattributes", BenthicAttributeViewSet, "benthicattribute")
+router.register(r"invertattributes", InvertAttributeViewSet, "invertattribute")
 router.register(r"fishfamilies", FishFamilyViewSet, "fishfamily")
 router.register(r"fishgenera", FishGenusViewSet, "fishgenus")
 router.register(r"fishspecies", FishSpeciesViewSet, "fishspecies")
@@ -129,6 +132,7 @@ project_router.register(r"sampleevents", SampleEventViewSet, "sampleevent")
 # sample units
 project_router.register(r"benthictransects", BenthicTransectViewSet, "benthictransect")
 project_router.register(r"fishbelttransects", FishBeltTransectViewSet, "fishbelttransect")
+project_router.register(r"invertbelttransects", InvertBeltTransectViewSet, "invertbelttransect")
 project_router.register(r"quadratcollections", QuadratCollectionViewSet, "quadratcollection")
 
 # multi model sample unit method views


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for invertebrate belt-transect records and hierarchical invert attributes (ancestry, parent, species fields).
  * Enabled offline sync for invert-attribute data.
  * Search now includes belt-invert observer first/last name.
  * Choice list for group-of-interest now includes per-item updated_on; report export shows updated class/group-of-interest sourcing.

* **Documentation**
  * Added guidance for integrating an attribute taxonomy API.

* **Tests**
  * Added fixtures and tests for invert attributes, belt-transect CRUD, filtering, access control, and search.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/mermaid-api/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->