### PR TITLE
deploy the sagemaker stack in dev as part of GH actions

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -70,7 +70,8 @@ jobs:
             GithubAccess \
             mermaid-api-infra-common \
             dev-mermaid-api-django \
-            dev-mermaid-static-site
+            dev-mermaid-static-site \
+            dev-mermaid-sagemaker
       - name: CDK Deploy PROD
         if: startsWith(github.ref, 'refs/tags')
         env:


### PR DESCRIPTION
The current deploy action doesn't deploy the sagemaker stack, and this change adds it.