### PR TITLE
[M1975] transect endpoint PUT/PATCH cleanup

### DIFF
--- a/src/api/resources/benthic_transect.py
+++ b/src/api/resources/benthic_transect.py
@@ -1,4 +1,5 @@
 import django_filters
+from rest_framework.exceptions import MethodNotAllowed
 
 from ..models import BenthicTransect
 from .base import BaseProjectApiViewSet
@@ -34,3 +35,9 @@ class BenthicTransectViewSet(BaseProjectApiViewSet):
     serializer_class = BenthicTransectSerializer
     queryset = BenthicTransect.objects.all()
     filterset_class = BenthicTransectFilterSet
+
+    def update(self, request, *args, **kwargs):
+        raise MethodNotAllowed("PUT")
+
+    def partial_update(self, request, *args, **kwargs):
+        raise MethodNotAllowed("PATCH")

--- a/src/api/resources/benthic_transect.py
+++ b/src/api/resources/benthic_transect.py
@@ -31,7 +31,7 @@ class BenthicTransectFilterSet(SampleUnitFilterSet):
 
 
 class BenthicTransectViewSet(BaseProjectApiViewSet):
-    http_method_names = ["get", "post", "delete", "head", "options"]
+    http_method_names = ["get", "post", "head", "delete"]
     serializer_class = BenthicTransectSerializer
     queryset = BenthicTransect.objects.all()
     filterset_class = BenthicTransectFilterSet

--- a/src/api/resources/benthic_transect.py
+++ b/src/api/resources/benthic_transect.py
@@ -1,5 +1,4 @@
 import django_filters
-from rest_framework.exceptions import MethodNotAllowed
 
 from ..models import BenthicTransect
 from .base import BaseProjectApiViewSet
@@ -32,12 +31,7 @@ class BenthicTransectFilterSet(SampleUnitFilterSet):
 
 
 class BenthicTransectViewSet(BaseProjectApiViewSet):
+    http_method_names = ["get", "post", "delete", "head", "options"]
     serializer_class = BenthicTransectSerializer
     queryset = BenthicTransect.objects.all()
     filterset_class = BenthicTransectFilterSet
-
-    def update(self, request, *args, **kwargs):
-        raise MethodNotAllowed("PUT")
-
-    def partial_update(self, request, *args, **kwargs):
-        raise MethodNotAllowed("PATCH")

--- a/src/api/resources/fish_belt_transect.py
+++ b/src/api/resources/fish_belt_transect.py
@@ -1,5 +1,4 @@
 import django_filters
-from rest_framework.exceptions import MethodNotAllowed
 
 from ..models import FishBeltTransect
 from .base import BaseProjectApiViewSet, ModelValReadOnlyField
@@ -46,12 +45,7 @@ class FishBeltTransectFilterSet(SampleUnitFilterSet):
 
 
 class FishBeltTransectViewSet(BaseProjectApiViewSet):
+    http_method_names = ["get", "post", "delete", "head", "options"]
     serializer_class = FishBeltTransectSerializer
     queryset = FishBeltTransect.objects.all()
     filterset_class = FishBeltTransectFilterSet
-
-    def update(self, request, *args, **kwargs):
-        raise MethodNotAllowed("PUT")
-
-    def partial_update(self, request, *args, **kwargs):
-        raise MethodNotAllowed("PATCH")

--- a/src/api/resources/fish_belt_transect.py
+++ b/src/api/resources/fish_belt_transect.py
@@ -45,7 +45,7 @@ class FishBeltTransectFilterSet(SampleUnitFilterSet):
 
 
 class FishBeltTransectViewSet(BaseProjectApiViewSet):
-    http_method_names = ["get", "post", "delete", "head", "options"]
+    http_method_names = ["get", "post", "head", "delete"]
     serializer_class = FishBeltTransectSerializer
     queryset = FishBeltTransect.objects.all()
     filterset_class = FishBeltTransectFilterSet

--- a/src/api/resources/invert_belt_transect.py
+++ b/src/api/resources/invert_belt_transect.py
@@ -1,7 +1,7 @@
 import django_filters
 from rest_framework.exceptions import MethodNotAllowed
 
-from ..models import FishBeltTransect
+from ..models import InvertBeltTransect
 from .base import BaseProjectApiViewSet, ModelValReadOnlyField
 from .sample_units_base import (
     SampleUnitExtendedSerializer,
@@ -10,45 +10,45 @@ from .sample_units_base import (
 )
 
 
-class FishBeltTransectExtendedSerializer(SampleUnitExtendedSerializer):
+class InvertBeltTransectExtendedSerializer(SampleUnitExtendedSerializer):
     width = ModelValReadOnlyField()
 
     class Meta:
-        model = FishBeltTransect
+        model = InvertBeltTransect
         exclude = []
 
 
-class FishBeltTransectSerializer(SampleUnitSerializer):
+class InvertBeltTransectSerializer(SampleUnitSerializer):
     class Meta:
-        model = FishBeltTransect
+        model = InvertBeltTransect
         exclude = []
         extra_kwargs = {
+            **SampleUnitSerializer.extra_kwargs,
             "number": {"error_messages": {"null": "Transect number is required"}},
             "len_surveyed": {"error_messages": {"null": "Transect length surveyed is required"}},
             "width": {"error_messages": {"null": "Width is required"}},
-            "size_bin": {"error_messages": {"null": "Fish size bin is required"}},
         }
-        extra_kwargs.update(SampleUnitSerializer.extra_kwargs)
 
 
-class FishBeltTransectFilterSet(SampleUnitFilterSet):
+class InvertBeltTransectFilterSet(SampleUnitFilterSet):
     len_surveyed = django_filters.RangeFilter(field_name="len_surveyed")
 
     class Meta:
-        model = FishBeltTransect
+        model = InvertBeltTransect
         fields = [
-            "beltfish_method",
+            "beltinvert_method",
             "sample_event",
             "len_surveyed",
             "width",
+            "size_bin",
             "depth",
         ] + SampleUnitFilterSet.fields
 
 
-class FishBeltTransectViewSet(BaseProjectApiViewSet):
-    serializer_class = FishBeltTransectSerializer
-    queryset = FishBeltTransect.objects.all()
-    filterset_class = FishBeltTransectFilterSet
+class InvertBeltTransectViewSet(BaseProjectApiViewSet):
+    serializer_class = InvertBeltTransectSerializer
+    queryset = InvertBeltTransect.objects.order_by("id")
+    filterset_class = InvertBeltTransectFilterSet
 
     def update(self, request, *args, **kwargs):
         raise MethodNotAllowed("PUT")

--- a/src/api/resources/invert_belt_transect.py
+++ b/src/api/resources/invert_belt_transect.py
@@ -1,5 +1,4 @@
 import django_filters
-from rest_framework.exceptions import MethodNotAllowed
 
 from ..models import InvertBeltTransect
 from .base import BaseProjectApiViewSet, ModelValReadOnlyField
@@ -46,12 +45,7 @@ class InvertBeltTransectFilterSet(SampleUnitFilterSet):
 
 
 class InvertBeltTransectViewSet(BaseProjectApiViewSet):
+    http_method_names = ["get", "post", "delete", "head", "options"]
     serializer_class = InvertBeltTransectSerializer
     queryset = InvertBeltTransect.objects.order_by("id")
     filterset_class = InvertBeltTransectFilterSet
-
-    def update(self, request, *args, **kwargs):
-        raise MethodNotAllowed("PUT")
-
-    def partial_update(self, request, *args, **kwargs):
-        raise MethodNotAllowed("PATCH")

--- a/src/api/resources/invert_belt_transect.py
+++ b/src/api/resources/invert_belt_transect.py
@@ -45,7 +45,7 @@ class InvertBeltTransectFilterSet(SampleUnitFilterSet):
 
 
 class InvertBeltTransectViewSet(BaseProjectApiViewSet):
-    http_method_names = ["get", "post", "delete", "head", "options"]
+    http_method_names = ["get", "post", "head", "delete"]
     serializer_class = InvertBeltTransectSerializer
     queryset = InvertBeltTransect.objects.order_by("id")
     filterset_class = InvertBeltTransectFilterSet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transect API endpoints (benthic, fish belt, invert belt) now enforce allowed HTTP methods, rejecting unsupported update operations (PUT/PATCH) and OPTIONS. Clients will receive proper method-not-allowed responses for disallowed requests, preventing accidental or unsupported updates and improving API predictability and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/mermaid-api/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->