### PR TITLE
Generalize SageMaker launcher IAM roles for classifier and segmentation

### DIFF
--- a/iac/nag_suppressions.py
+++ b/iac/nag_suppressions.py
@@ -546,17 +546,19 @@ def suppress_sagemaker(stack: Stack, prefix: str) -> None:
             ],
         )
 
-    # --- Mermaid classifier launcher role's inline policies ---
-    # ECR / SageMaker / S3 wildcards are scoped to specific repos
-    # (mermaid-classifier-*), training jobs in this account, and the
-    # runs/* prefix of the SageMaker data bucket. Required by the
-    # launcher scripts to pull the training image, launch training jobs, and read/write
-    # training data and logs.
+    # --- Shared Mermaid SageMaker launcher role's inline policies ---
+    # ECR / SageMaker / Logs / S3 wildcards are scoped to specific repos
+    # (mermaid-*-jobs), Training+Processing jobs in this account, the
+    # /aws/sagemaker/* CloudWatch log groups, and the runs/* prefix of
+    # the SageMaker data bucket. Required by the launcher scripts to
+    # pull the job image, submit Training/Processing jobs, tail logs,
+    # and read/write run data.
     for policy_path in [
-        "MermaidClassifierLauncherEcrPolicy/Resource",
-        "MermaidClassifierLauncherSagemakerPolicy/Resource",
-        "MermaidClassifierLauncherPassRolePolicy/Resource",
-        f"{prefix}MermaidClassifierLauncherRole/DefaultPolicy/Resource",
+        "MermaidSagemakerLauncherEcrPolicy/Resource",
+        "MermaidSagemakerLauncherSagemakerPolicy/Resource",
+        "MermaidSagemakerLauncherLogsPolicy/Resource",
+        "MermaidSagemakerLauncherPassRolePolicy/Resource",
+        f"{prefix}MermaidSagemakerLauncherRole/DefaultPolicy/Resource",
     ]:
         _suppress_by_path(
             stack,
@@ -564,9 +566,10 @@ def suppress_sagemaker(stack: Stack, prefix: str) -> None:
             [
                 NagPackSuppression(
                     id="AwsSolutions-IAM5",
-                    reason=f"{ACCEPTED}: Wildcards are scoped to mermaid-classifier-* "
-                    "ECR repos, SageMaker training jobs in this account, and the "
-                    "runs/* prefix of the SageMaker data bucket.",
+                    reason=f"{ACCEPTED}: Wildcards are scoped to mermaid-*-jobs "
+                    "ECR repos, SageMaker Training+Processing jobs in this account, "
+                    "/aws/sagemaker/* CloudWatch log groups, and the runs/* prefix "
+                    "of the SageMaker data bucket.",
                 ),
             ],
         )

--- a/iac/sagemaker-launcher-convention.md
+++ b/iac/sagemaker-launcher-convention.md
@@ -1,0 +1,229 @@
+# SageMaker launcher convention (cross-repo)
+
+This document is the **contract** for the per-repo SageMaker launcher
+scripts in `mermaid-classifier` and `mermaid-segmentation`. Each repo
+has its own copies of `scripts/launch_training.py` and
+`scripts/launch_processing.py`. They are not shared code, but they all
+follow this convention so users can move between repos without
+relearning the system.
+
+## Account and region
+
+- Account: `554812291621` (dev)
+- Region: `us-east-1`
+
+All resources below live in this account/region.
+
+## Identity Center permission set
+
+Users sign in via SSO to the `SageMaker` Identity Center permission set.
+Its inline policy contains exactly these two statements (paste verbatim
+if missing):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeMermaidSagemakerLauncher",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::554812291621:role/dev-mermaid-sagemaker-launcher-role"
+    },
+    {
+      "Sid": "CloudWatchLogsForSagemakerJobs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents",
+        "logs:StartLiveTail"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:554812291621:log-group:/aws/sagemaker/*"
+    }
+  ]
+}
+```
+
+The `AssumeRole` statement lets users role-chain from SSO into the
+launcher role (which holds the actual job-submission permissions). The
+CloudWatch statement is needed for the **AWS Console** to display logs
+— the console uses the SSO session, not the chained role.
+
+## ~/.aws/config
+
+```ini
+[profile wcs-sso]
+sso_start_url      = <your-aws-sso-portal>
+sso_region         = us-east-1
+sso_account_id     = 554812291621
+sso_role_name      = SageMaker
+region             = us-east-1
+output             = json
+
+[profile wcs-launcher]
+source_profile     = wcs-sso
+role_arn           = arn:aws:iam::554812291621:role/dev-mermaid-sagemaker-launcher-role
+region             = us-east-1
+duration_seconds   = 28800
+```
+
+```bash
+aws sso login --profile wcs-sso
+export AWS_PROFILE=wcs-launcher
+aws sts get-caller-identity   # should end .../dev-mermaid-sagemaker-launcher-role/...
+```
+
+## Canonical ARNs
+
+| Resource | ARN |
+|---|---|
+| Launcher role | `arn:aws:iam::554812291621:role/dev-mermaid-sagemaker-launcher-role` |
+| Job execution role | `arn:aws:iam::554812291621:role/dev-sm-execution-role` |
+| Staging bucket | `s3://dev-datamermaid-sm-data` |
+| Classifier ECR | `554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs` |
+| Segmentation ECR | `554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs` |
+| MLflow App (classifier) | `arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-2OMU4VP53ZS2` (pyspacer) |
+| MLflow App (segmentation) | `arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-EJVJ6AVFDWW2` (mermaidseg) |
+
+## Per-run YAML schema
+
+Every run is described by a YAML file. The launcher validates against
+this schema; unknown top-level keys raise. Required fields are marked
+with `*`.
+
+```yaml
+job:
+  name_prefix: <string>*           # e.g. mermaid-features-2605. Used as
+                                   # the SageMaker job name prefix.
+  image: <string>*                 # `<repo-short-name>:<tag>` (launcher
+                                   # expands to the full ECR URI based on
+                                   # which repo it lives in), OR a full
+                                   # ECR URI (any account/repo) to override.
+  entrypoint: <path-in-container>* # Script to run, e.g.
+                                   # `scripts/build_feature_bucket.py`.
+  instance_type: <ml.* string>*
+  instance_count: <int>            # default 1 (TrainingJob only — Processing
+                                   # always uses 1)
+  volume_gb: <int>*
+  max_runtime_hours: <int>*
+  use_spot: <bool>                 # default false (TrainingJob only)
+  env:                             # extra container env vars
+    KEY: VALUE
+  tags:                            # extra SageMaker tags
+    KEY: VALUE
+
+# Optional. Only on launch_processing.py YAMLs.
+processing:
+  container_args: [<string>, ...]  # ContainerArguments (positional)
+  shard:                           # optional fan-out
+    items_from: <path>             # path relative to the config dir
+    items_column: <string>         # CSV column name; auto-detect if omitted
+    workers: <int>
+    per_worker_arg: <string>       # e.g. --source-ids (script flag taking
+                                   # the comma-separated chunk)
+
+# Optional. Only on launch_training.py YAMLs.
+training:
+  hyperparameters:                 # SageMaker hyperparameters dict
+    KEY: VALUE
+  channels:                        # extra input channels beyond `config`
+    channel_name:
+      s3_uri: s3://...
+      input_mode: File|FastFile|Pipe
+```
+
+## Launcher-enforced invariants (NOT YAML-overridable)
+
+- `RoleArn` on the job is always `dev-sm-execution-role` (canonical ARN above).
+- `OutputDataConfig.S3OutputPath` is always `s3://dev-datamermaid-sm-data/runs/<run-id>/output/`.
+- `config` channel uploaded from the local `--config-dir` lands at:
+  - `/opt/ml/input/data/config/` for TrainingJob.
+  - `/opt/ml/processing/input/config/` for ProcessingJob.
+- `run-id` is always `<job.name_prefix>-<UTC-YYYYMMDDTHHMMSSZ>`.
+- Region is always `us-east-1`.
+- MLflow tracking URI comes from the launcher CLI flag `--mlflow-tracking-uri` and is injected as env `MLFLOW_TRACKING_SERVER`. Not YAML-configurable.
+
+## Launcher CLI shape (identical across repos)
+
+```bash
+uv run python scripts/launch_training.py \
+    --run-config sagemaker/runs/my-run.yaml \
+    --config-dir sagemaker/configs/my-run/ \
+    --mlflow-tracking-uri arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/<app-id> \
+    [--dry-run]
+
+uv run python scripts/launch_processing.py \
+    --run-config sagemaker/runs/my-extraction.yaml \
+    --config-dir sagemaker/configs/my-extraction/ \
+    [--dry-run] [--no-wait]
+```
+
+The launcher must print, at submission time:
+1. Run ID
+2. Job ARN
+3. CloudWatch log URL
+4. (training only) MLflow App URL
+
+## ECR tagging convention
+
+Each repo's ECR holds many independently-tagged images. Two project
+images may coexist in one repo (e.g. classifier has both a CPU
+training image and a GPU feature-extraction image — different
+Dockerfiles, same repo, different tag prefixes).
+
+| Tag pattern | Meaning | Who pushes |
+|---|---|---|
+| `:training-latest` | Latest training-purpose image. CPU-only by convention in mermaid-classifier; GPU in mermaid-segmentation. | Anyone with launcher role |
+| `:features-latest` | (mermaid-classifier only) Latest GPU feature-extraction image. | Anyone |
+| `:processing-latest` | (mermaid-segmentation only) Latest GPU processing image. | Anyone |
+| `:smoke` | Image known to pass the repo's local smoke recipe. Promoted manually. | Anyone |
+| `:prod-YYYY-MM-DD` | Pinned production build. Don't overwrite. | Anyone, by convention |
+| `:user-<name>-<purpose>-YYYY-MM-DD` | Personal experimental tags. e.g. `:user-greg-eval-2026-05-25`. | The named user |
+
+The launcher YAML's `job.image` field accepts either a short form
+(`<repo>:<tag>`, where `<repo>` is the bare repo name and the launcher
+expands the ECR URI for that repo) or a full ECR URI (for cross-repo or
+external overrides).
+
+### Build/push recipe
+
+```bash
+export AWS_PROFILE=wcs-launcher
+ACCT=554812291621
+REGION=us-east-1
+REPO=mermaid-classifier-jobs        # or mermaid-segmentation-jobs
+TAG=user-$USER-$(date +%Y-%m-%d)    # or whatever convention applies
+
+aws ecr get-login-password --region $REGION \
+    | docker login --username AWS --password-stdin \
+        $ACCT.dkr.ecr.$REGION.amazonaws.com
+
+docker buildx build --platform linux/amd64 \
+    -t $ACCT.dkr.ecr.$REGION.amazonaws.com/$REPO:$TAG \
+    -f docker/jobs/<which>.Dockerfile .
+
+docker push $ACCT.dkr.ecr.$REGION.amazonaws.com/$REPO:$TAG
+```
+
+## MLflow tracking
+
+- The classifier uses the **pyspacer** MLflow app.
+- The segmentation repo uses the **mermaidseg** MLflow app.
+- The execution role (`dev-sm-execution-role`) already has
+  `sagemaker-mlflow:*` on `*`, which covers both apps.
+- Each repo's docs should embed the relevant app ARN in its example
+  `--mlflow-tracking-uri` invocation.
+
+## Checklist for new launcher PRs (any repo)
+
+- [ ] `launch_training.py` and/or `launch_processing.py` follow the CLI shape above.
+- [ ] Per-run YAML schema matches this doc; unknown top-level keys raise.
+- [ ] Launcher-enforced invariants (above) are not YAML-overridable.
+- [ ] `--dry-run` prints the planned config without submitting.
+- [ ] CloudWatch URL is printed at submission time.
+- [ ] (training only) MLflow App URL is printed at submission time.
+- [ ] boto3 errors surface cleanly (no swallowed exceptions).
+- [ ] Local smoke recipe present (`docker/jobs/local_smoke.sh`).
+- [ ] Unit tests cover schema, dry-run, request shape, and (for processing) shard math.

--- a/iac/sagemaker-launcher-convention.md
+++ b/iac/sagemaker-launcher-convention.md
@@ -17,7 +17,7 @@ All resources below live in this account/region.
 ## Identity Center permission set
 
 Users sign in via SSO to the `SageMaker` Identity Center permission set.
-Its inline policy contains exactly these two statements (paste verbatim
+Its inline policy contains exactly these statements (paste verbatim
 if missing):
 
 ```json
@@ -31,16 +31,24 @@ if missing):
       "Resource": "arn:aws:iam::554812291621:role/dev-mermaid-sagemaker-launcher-role"
     },
     {
-      "Sid": "CloudWatchLogsForSagemakerJobs",
+      "Sid": "DescribeAllLogGroups",
+      "Effect": "Allow",
+      "Action": "logs:DescribeLogGroups",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReadSagemakerJobLogs",
       "Effect": "Allow",
       "Action": [
-        "logs:DescribeLogGroups",
         "logs:DescribeLogStreams",
         "logs:GetLogEvents",
         "logs:FilterLogEvents",
         "logs:StartLiveTail"
       ],
-      "Resource": "arn:aws:logs:us-east-1:554812291621:log-group:/aws/sagemaker/*"
+      "Resource": [
+        "arn:aws:logs:us-east-1:554812291621:log-group:/aws/sagemaker/*",
+        "arn:aws:logs:us-east-1:554812291621:log-group:/aws/sagemaker/*:*"
+      ]
     }
   ]
 }

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -413,11 +413,11 @@ class SagemakerStack(cdk.Stack):
             )
         )
 
-        # SageMaker: submit + observe training jobs the launcher creates.
+        # SageMaker: submit + observe both Training and Processing jobs.
         role.attach_inline_policy(
             iam.Policy(
                 self,
-                "MermaidClassifierLauncherSagemakerPolicy",
+                "MermaidSagemakerLauncherSagemakerPolicy",
                 statements=[
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,
@@ -425,23 +425,27 @@ class SagemakerStack(cdk.Stack):
                             "sagemaker:CreateTrainingJob",
                             "sagemaker:DescribeTrainingJob",
                             "sagemaker:StopTrainingJob",
-                            "sagemaker:ListTrainingJobs",
+                            "sagemaker:CreateProcessingJob",
+                            "sagemaker:DescribeProcessingJob",
+                            "sagemaker:StopProcessingJob",
                             "sagemaker:AddTags",
                             "sagemaker:ListTags",
                         ],
                         resources=[
                             f"arn:aws:sagemaker:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"
                             ":training-job/*",
+                            f"arn:aws:sagemaker:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"
+                            ":processing-job/*",
                         ],
                     ),
-                    # ListTrainingJobs ignores the resource scope but
-                    # requires the action on '*'. Same for the MLflow
-                    # presigned-URL helper if the operator wants to
-                    # spot-check the UI.
+                    # List* actions ignore the resource scope but require
+                    # the action on '*'. Same for the MLflow presigned-URL
+                    # helper if the operator wants to spot-check the UI.
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,
                         actions=[
                             "sagemaker:ListTrainingJobs",
+                            "sagemaker:ListProcessingJobs",
                             "sagemaker:ListMlflowApps",
                             "sagemaker:DescribeMlflowApp",
                             "sagemaker:CreatePresignedMlflowAppUrl",

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -460,6 +460,40 @@ class SagemakerStack(cdk.Stack):
             )
         )
 
+        # CloudWatch Logs: tail TrainingJob + ProcessingJob logs from the
+        # operator's laptop. The launcher prints CloudWatch URLs at job
+        # submission time; `aws logs tail` works from the assumed-role
+        # session via these grants. DescribeLogGroups must be on '*' --
+        # the CloudWatch API rejects scoped DescribeLogGroups by design.
+        role.attach_inline_policy(
+            iam.Policy(
+                self,
+                "MermaidSagemakerLauncherLogsPolicy",
+                statements=[
+                    iam.PolicyStatement(
+                        effect=iam.Effect.ALLOW,
+                        actions=["logs:DescribeLogGroups"],
+                        resources=["*"],
+                    ),
+                    iam.PolicyStatement(
+                        effect=iam.Effect.ALLOW,
+                        actions=[
+                            "logs:DescribeLogStreams",
+                            "logs:GetLogEvents",
+                            "logs:FilterLogEvents",
+                            "logs:StartLiveTail",
+                        ],
+                        resources=[
+                            f"arn:aws:logs:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"
+                            ":log-group:/aws/sagemaker/*",
+                            f"arn:aws:logs:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"
+                            ":log-group:/aws/sagemaker/*:*",
+                        ],
+                    ),
+                ],
+            )
+        )
+
         # iam:PassRole on the existing SageMaker execution role -- required
         # to call CreateTrainingJob with RoleArn = sm_execution_role.
         role.attach_inline_policy(

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -428,6 +428,9 @@ class SagemakerStack(cdk.Stack):
                             "sagemaker:CreateProcessingJob",
                             "sagemaker:DescribeProcessingJob",
                             "sagemaker:StopProcessingJob",
+                            # AddTags/ListTags apply to both job types,
+                            # so they're kept on this resource-scoped
+                            # statement rather than the unscoped one below.
                             "sagemaker:AddTags",
                             "sagemaker:ListTags",
                         ],

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -110,7 +110,7 @@ class SagemakerStack(cdk.Stack):
         # the cross-repo contract.
         self.classifier_jobs_repo = self.create_classifier_jobs_repo()
         self.segmentation_jobs_repo = self.create_segmentation_jobs_repo()
-        self.classifier_launcher_role = self.create_classifier_launcher_role()
+        self.sagemaker_launcher_role = self.create_sagemaker_launcher_role()
 
         self.security_group = ec2.SecurityGroup(
             self,
@@ -341,18 +341,18 @@ class SagemakerStack(cdk.Stack):
 
         return repo
 
-    def create_classifier_launcher_role(self) -> iam.Role:
-        """IAM role for operators driving the mermaid-classifier launcher.
+    def create_sagemaker_launcher_role(self) -> iam.Role:
+        """IAM role for operators driving the mermaid-* launchers.
 
+        Single shared role used by both mermaid-classifier and
+        mermaid-segmentation launcher scripts (training + processing jobs).
         Trust: any principal in this account whose ARN matches the
-        SageMaker SSO permission set (so the role is assumable directly
-        from a `wcs-sm`-style profile via role-chaining).
+        SageMaker SSO permission set.
 
-        Permissions: scoped to what the launcher actually needs --
-        push/pull on the `mermaid-classifier-*` ECR repos, submit and
-        observe SageMaker TrainingJobs, pass the existing SageMaker
-        execution role as the job's RoleArn, and read/write the
-        run-scoped prefix in the SageMaker data bucket.
+        Permissions: push/pull on the `mermaid-*-jobs` ECR repos, submit and
+        observe SageMaker Training+Processing jobs, pass the existing
+        SageMaker execution role as the job's RoleArn, read/write the
+        run-scoped prefix in the SageMaker data bucket, tail CloudWatch logs.
         """
         sso_principal = iam.PrincipalWithConditions(
             iam.AccountPrincipal(cdk.Aws.ACCOUNT_ID),
@@ -369,18 +369,18 @@ class SagemakerStack(cdk.Stack):
 
         role = iam.Role(
             self,
-            f"{self.prefix}MermaidClassifierLauncherRole",
+            f"{self.prefix}MermaidSagemakerLauncherRole",
             assumed_by=sso_principal,
-            role_name=f"{self.prefix}-mermaid-classifier-launcher-role",
+            role_name=f"{self.prefix}-mermaid-sagemaker-launcher-role",
             max_session_duration=cdk.Duration.hours(8),
         )
 
-        # ECR: token + push/pull/manage on mermaid-classifier-* repos in
-        # this account. GetAuthorizationToken must be on '*' (AWS rule).
+        # ECR: token + push/pull/manage on mermaid-*-jobs repos in this
+        # account. GetAuthorizationToken must be on '*' (AWS rule).
         role.attach_inline_policy(
             iam.Policy(
                 self,
-                "MermaidClassifierLauncherEcrPolicy",
+                "MermaidSagemakerLauncherEcrPolicy",
                 statements=[
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,
@@ -405,7 +405,7 @@ class SagemakerStack(cdk.Stack):
                         ],
                         resources=[
                             f"arn:aws:ecr:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"
-                            ":repository/mermaid-classifier-*",
+                            ":repository/mermaid-*-jobs",
                         ],
                     ),
                 ],
@@ -478,10 +478,10 @@ class SagemakerStack(cdk.Stack):
 
         CfnOutput(
             self,
-            f"{self.prefix}MermaidClassifierLauncherRoleArn",
+            f"{self.prefix}MermaidSagemakerLauncherRoleArn",
             value=role.role_arn,
-            description="IAM role for operators driving the mermaid-classifier launcher",
-            export_name=f"{self.prefix}-MermaidClassifierLauncherRoleArn",
+            description="IAM role for operators driving the mermaid-* launchers",
+            export_name=f"{self.prefix}-MermaidSagemakerLauncherRoleArn",
         )
 
         return role

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -104,8 +104,10 @@ class SagemakerStack(cdk.Stack):
 
         self.pyspacer_test.grant_read(self.sm_execution_role)
 
-        # ECR repository + IAM role for the mermaid-classifier SageMaker
-        # training launcher.
+        # ECR repositories + shared IAM role for the mermaid-* SageMaker
+        # launchers (both classifier and segmentation, both Training and
+        # Processing jobs). See iac/sagemaker-launcher-convention.md for
+        # the cross-repo contract.
         self.classifier_jobs_repo = self.create_classifier_jobs_repo()
         self.segmentation_jobs_repo = self.create_segmentation_jobs_repo()
         self.classifier_launcher_role = self.create_classifier_launcher_role()
@@ -277,8 +279,8 @@ class SagemakerStack(cdk.Stack):
         Tag-based separation (`:training-latest`, `:features-latest`,
         `:user-<name>-...`) within a single repo; the launcher role's ECR
         resource pattern is `mermaid-*-jobs` to cover both this and the
-        segmentation repo. Tagging conventions documented in the convention
-        doc.
+        segmentation repo. Tagging conventions documented in
+        `iac/sagemaker-launcher-convention.md`.
         """
         repo = ecr.Repository(
             self,

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -501,11 +501,11 @@ class SagemakerStack(cdk.Stack):
         )
 
         # iam:PassRole on the existing SageMaker execution role -- required
-        # to call CreateTrainingJob with RoleArn = sm_execution_role.
+        # to call CreateTraining/ProcessingJob with RoleArn = sm_execution_role.
         role.attach_inline_policy(
             iam.Policy(
                 self,
-                "MermaidClassifierLauncherPassRolePolicy",
+                "MermaidSagemakerLauncherPassRolePolicy",
                 statements=[
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -107,6 +107,7 @@ class SagemakerStack(cdk.Stack):
         # ECR repository + IAM role for the mermaid-classifier SageMaker
         # training launcher.
         self.classifier_training_repo = self.create_classifier_training_repo()
+        self.segmentation_jobs_repo = self.create_segmentation_jobs_repo()
         self.classifier_launcher_role = self.create_classifier_launcher_role()
 
         self.security_group = ec2.SecurityGroup(
@@ -298,6 +299,39 @@ class SagemakerStack(cdk.Stack):
             value=repo.repository_uri,
             description="ECR URI for the mermaid-classifier training image",
             export_name=f"{self.prefix}-MermaidClassifierTrainingRepoUri",
+        )
+
+        return repo
+
+    def create_segmentation_jobs_repo(self) -> ecr.Repository:
+        """ECR repository for the mermaid-segmentation SageMaker job image.
+
+        Mirrors the classifier-jobs repo: shared `mermaid-*-jobs` naming so
+        the launcher role's ECR resource pattern covers both. Tag-based
+        separation (e.g. `:training-latest`, `:processing-latest`,
+        `:user-<name>-...`) is documented in the convention doc.
+        """
+        repo = ecr.Repository(
+            self,
+            f"{self.prefix}MermaidSegmentationJobsRepo",
+            repository_name="mermaid-segmentation-jobs",
+            image_scan_on_push=True,
+            removal_policy=cdk.RemovalPolicy.RETAIN,
+            lifecycle_rules=[
+                ecr.LifecycleRule(
+                    description="Keep last 10 images",
+                    max_image_count=10,
+                    rule_priority=1,
+                ),
+            ],
+        )
+
+        CfnOutput(
+            self,
+            f"{self.prefix}MermaidSegmentationJobsRepoUri",
+            value=repo.repository_uri,
+            description="ECR URI for the mermaid-segmentation jobs image",
+            export_name=f"{self.prefix}-MermaidSegmentationJobsRepoUri",
         )
 
         return repo

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -106,7 +106,7 @@ class SagemakerStack(cdk.Stack):
 
         # ECR repository + IAM role for the mermaid-classifier SageMaker
         # training launcher.
-        self.classifier_training_repo = self.create_classifier_training_repo()
+        self.classifier_jobs_repo = self.create_classifier_jobs_repo()
         self.segmentation_jobs_repo = self.create_segmentation_jobs_repo()
         self.classifier_launcher_role = self.create_classifier_launcher_role()
 
@@ -271,17 +271,19 @@ class SagemakerStack(cdk.Stack):
 
         return role
 
-    def create_classifier_training_repo(self) -> ecr.Repository:
-        """ECR repository for the mermaid-classifier SageMaker training image.
+    def create_classifier_jobs_repo(self) -> ecr.Repository:
+        """ECR repository for the mermaid-classifier SageMaker job image.
 
-        Image tags are promoted by the launcher operator (`smoke`, `latest`,
-        date-stamped, etc.); only the most recent few tags need to live in
-        the registry, so an image lifecycle rule keeps history bounded.
+        Tag-based separation (`:training-latest`, `:features-latest`,
+        `:user-<name>-...`) within a single repo; the launcher role's ECR
+        resource pattern is `mermaid-*-jobs` to cover both this and the
+        segmentation repo. Tagging conventions documented in the convention
+        doc.
         """
         repo = ecr.Repository(
             self,
-            f"{self.prefix}MermaidClassifierTrainingRepo",
-            repository_name="mermaid-classifier-training",
+            f"{self.prefix}MermaidClassifierJobsRepo",
+            repository_name="mermaid-classifier-jobs",
             image_scan_on_push=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             lifecycle_rules=[
@@ -295,10 +297,10 @@ class SagemakerStack(cdk.Stack):
 
         CfnOutput(
             self,
-            f"{self.prefix}MermaidClassifierTrainingRepoUri",
+            f"{self.prefix}MermaidClassifierJobsRepoUri",
             value=repo.repository_uri,
-            description="ECR URI for the mermaid-classifier training image",
-            export_name=f"{self.prefix}-MermaidClassifierTrainingRepoUri",
+            description="ECR URI for the mermaid-classifier jobs image",
+            export_name=f"{self.prefix}-MermaidClassifierJobsRepoUri",
         )
 
         return repo
@@ -306,8 +308,7 @@ class SagemakerStack(cdk.Stack):
     def create_segmentation_jobs_repo(self) -> ecr.Repository:
         """ECR repository for the mermaid-segmentation SageMaker job image.
 
-        Sibling of `create_classifier_training_repo` (renamed to
-        `create_classifier_jobs_repo` later in this PR). Both repos share
+        Sibling of `create_classifier_jobs_repo`. Both repos share
         the `mermaid-*-jobs` naming pattern so the launcher role's ECR
         resource ARN can target them with a single wildcard. Tag-based
         separation (e.g. `:training-latest`, `:processing-latest`,

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -478,11 +478,17 @@ class SagemakerStack(cdk.Stack):
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,
                         actions=[
+                            # Read/query actions:
                             "logs:DescribeLogStreams",
                             "logs:GetLogEvents",
                             "logs:FilterLogEvents",
+                            # Interactive streaming (separate IAM action):
                             "logs:StartLiveTail",
                         ],
+                        # Two-form ARN: the bare log-group ARN covers
+                        # the group itself; the `:*` suffix covers its
+                        # streams. StartLiveTail/GetLogEvents require
+                        # the stream-level form.
                         resources=[
                             f"arn:aws:logs:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"
                             ":log-group:/aws/sagemaker/*",

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -243,9 +243,10 @@ class SagemakerStack(cdk.Stack):
             )
         )
 
-        # Allow this role to be passed as the SageMaker TrainingJob execution
-        # role. Required by the mermaid-classifier launcher which calls
-        # CreateTrainingJob with RoleArn = dev-sm-execution-role.
+        # Allow this role to be passed as the SageMaker Training/Processing
+        # job execution role. Required by the mermaid-* launchers (classifier
+        # and segmentation) which call Create{Training,Processing}Job with
+        # RoleArn = dev-sm-execution-role.
         role.attach_inline_policy(
             iam.Policy(
                 self,

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -402,7 +402,6 @@ class SagemakerStack(cdk.Stack):
                             "ecr:CompleteLayerUpload",
                             "ecr:PutImage",
                             "ecr:BatchDeleteImage",
-                            "ecr:DeleteRepository",
                         ],
                         resources=[
                             f"arn:aws:ecr:{cdk.Aws.REGION}:{cdk.Aws.ACCOUNT_ID}"

--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -306,8 +306,10 @@ class SagemakerStack(cdk.Stack):
     def create_segmentation_jobs_repo(self) -> ecr.Repository:
         """ECR repository for the mermaid-segmentation SageMaker job image.
 
-        Mirrors the classifier-jobs repo: shared `mermaid-*-jobs` naming so
-        the launcher role's ECR resource pattern covers both. Tag-based
+        Sibling of `create_classifier_training_repo` (renamed to
+        `create_classifier_jobs_repo` later in this PR). Both repos share
+        the `mermaid-*-jobs` naming pattern so the launcher role's ECR
+        resource ARN can target them with a single wildcard. Tag-based
         separation (e.g. `:training-latest`, `:processing-latest`,
         `:user-<name>-...`) is documented in the convention doc.
         """


### PR DESCRIPTION
As part of https://github.com/data-mermaid/mermaid-classifier/issues/43, we are setting up generalized access so that data scientists can submit Sagemaker training and processing jobs as needed from their local machines.

The setup matches what was already being done for the mermaid-classifier, except generalizes it so that the same IAM Roles can be used for both the classifier and the segmentation models.

Included in this PR is also a `launcher_convention` document that outlines the contract which is to be used by both repos. Since we don't have a single souce of truth for this document to live in, I put it here alongside the permissions changes so that both models can reference it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured SageMaker infrastructure to support both classifier and segmentation job launchers with a unified launcher role, separate container image repositories, and enhanced IAM permissions covering both job types and logging.

* **Documentation**
  * Added SageMaker launcher conventions guide documenting shared standards for launcher implementation, configuration schemas, invocation requirements, and deployment checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/mermaid-api/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->