### PR TITLE
Write permissions for sagemaker execution on 2605 coralnet bucket

### DIFF
--- a/iac/stacks/sagemaker.py
+++ b/iac/stacks/sagemaker.py
@@ -85,16 +85,17 @@ class SagemakerStack(cdk.Stack):
 
         self.coralnet_public_sources.grant_read(self.sm_execution_role)
 
-        # Feature-vector bucket used as the input store for the SageMaker
-        # training launcher (mermaid-classifier). Holds per-source .fv files
-        # produced by the feature-extraction pipeline.
+        # Feature-vector bucket used by two mermaid-classifier launchers:
+        # the feature-extraction ProcessingJob writes per-source .fv files
+        # and annotations.csv into it; the training launcher reads them back.
+        # Hence read+write, not read-only.
         self.coralnet_feature_vectors = s3.Bucket.from_bucket_arn(
             self,
             f"{self.prefix}CoralnetFeatureVectorsBucket",
             bucket_arn="arn:aws:s3:::2605-coralnet-public-sources",
         )
 
-        self.coralnet_feature_vectors.grant_read(self.sm_execution_role)
+        self.coralnet_feature_vectors.grant_read_write(self.sm_execution_role)
 
         self.pyspacer_test = s3.Bucket.from_bucket_arn(
             self,


### PR DESCRIPTION
In order to write new feature vectors to the [2605-coralnet-public-sources](https://us-east-1.console.aws.amazon.com/s3/buckets/2605-coralnet-public-sources?region=us-east-1) bucket using processing jobs, we need to give write permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated SageMaker permissions to enable seamless data flow between feature extraction and model training stages for shared feature vector processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/data-mermaid/mermaid-api/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->