### PR TITLE
migration merge and adot warning

### DIFF
--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -202,7 +202,11 @@ class ApiStack(Stack):
             "SQS_QUEUE_NAME": sqs_queue_name,
             "IMAGE_SQS_QUEUE_NAME": image_sqs_queue_name,
             # OpenTelemetry / X-Ray
+            # ecs-xray.yaml only configures a traces pipeline; disable metrics and
+            # logs exporters to suppress UNIMPLEMENTED errors from the ADOT sidecar.
             "OTEL_TRACES_EXPORTER": "otlp",
+            "OTEL_METRICS_EXPORTER": "none",
+            "OTEL_LOGS_EXPORTER": "none",
             "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
             "OTEL_PROPAGATORS": "xray",
             "OTEL_PYTHON_ID_GENERATOR": "xray",

--- a/src/api/migrations/0117_merge_0116_annotation_benthic_attribute_protect_0116_remove_invert_harvest_type.py
+++ b/src/api/migrations/0117_merge_0116_annotation_benthic_attribute_protect_0116_remove_invert_harvest_type.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0116_annotation_benthic_attribute_protect"),
+        ("api", "0116_remove_invert_harvest_type"),
+    ]
+
+    operations = []


### PR DESCRIPTION
In response to error
```
Starting Django Migrations
CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0116_annotation_benthic_attribute_protect, 0116_remove_invert_harvest_type in api).
To fix them run 'python manage.py makemigrations --merge'
```

and a warning
```
Failed to export metrics to localhost:4317, error code:       
  StatusCode.UNIMPLEMENTED
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated telemetry configuration to disable metrics and logs exporting while maintaining traces exporting.
  * Added database migration to resolve schema conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->