### PR TITLE
cost anomaly detection and alerting

### DIFF
--- a/iac/app.py
+++ b/iac/app.py
@@ -73,6 +73,7 @@ dev_api_stack = ApiStack(
     sagemaker_domain_name=f"{DEV_SETTINGS.env_id}-SG-Project",
     use_fifo_queues="False",
     report_s3_creds=common_stack.report_s3_creds,
+    cost_alerts_topic=common_stack.cost_alerts_topic,
 )
 
 dev_sagemaker_stack = SagemakerStack(
@@ -114,6 +115,7 @@ prod_api_stack = ApiStack(
     sagemaker_domain_name=f"{PROD_SETTINGS.env_id}-SG-Project",
     use_fifo_queues="False",
     report_s3_creds=common_stack.report_s3_creds,
+    cost_alerts_topic=common_stack.cost_alerts_topic,
 )
 
 nag_suppressions.apply_all(

--- a/iac/nag_suppressions.py
+++ b/iac/nag_suppressions.py
@@ -351,6 +351,22 @@ def suppress_common(stack: Stack) -> None:
         ],
     )
 
+    # --- Cost Anomaly Detection SNS topic ---
+    _suppress_by_path(
+        stack,
+        "CostAlertsTopic/Resource",
+        [
+            NagPackSuppression(
+                id="AwsSolutions-SNS2",
+                reason=f"{TODO}: Encrypt the cost alerts SNS topic with a KMS CMK.",
+            ),
+            NagPackSuppression(
+                id="AwsSolutions-SNS3",
+                reason=f"{TODO}: Add aws:SecureTransport condition to the cost alerts SNS topic policy.",
+            ),
+        ],
+    )
+
 
 # ---------------------------------------------------------------------------
 # StaticSiteStack

--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -22,6 +22,7 @@ from aws_cdk import (
     aws_route53_targets as r53_targets,
     aws_s3 as s3,
     aws_secretsmanager as secrets,
+    aws_sns as sns,
 )
 from constructs import Construct
 from settings.settings import ProjectSettings
@@ -57,6 +58,7 @@ class ApiStack(Stack):
         sagemaker_domain_name: str,
         use_fifo_queues: str,
         report_s3_creds: secrets.Secret,
+        cost_alerts_topic: sns.ITopic | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -507,4 +509,5 @@ class ApiStack(Stack):
             sagemaker_domain_name=sagemaker_domain_name,
             slack_workspace_id=config.api.slack_workspace_id or None,
             slack_channel_id=config.api.slack_channel_id or None,
+            cost_alerts_topic=cost_alerts_topic,
         )

--- a/iac/stacks/common.py
+++ b/iac/stacks/common.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     Stack,
     aws_athena as athena,
     aws_autoscaling as autoscale,
+    aws_ce as ce,
     aws_certificatemanager as acm,
     aws_ec2 as ec2,
     aws_ecs as ecs,
@@ -18,6 +19,7 @@ from aws_cdk import (
     aws_route53 as r53,
     aws_s3 as s3,
     aws_secretsmanager as sm,
+    aws_sns as sns,
     aws_wafv2 as wafv2,
 )
 from constructs import Construct
@@ -773,6 +775,44 @@ class CommonStack(Stack):
                 ),
                 generate_string_key="password",
             ),
+        )
+
+        # ── AWS Cost Anomaly Detection ────────────────────────────────
+        # Account-wide monitor covering all AWS services. Deployed in
+        # CommonStack so it is created once (not per-env) and can be
+        # validated in dev before prod rollout.
+        # Alerts when any service spend deviates by more than $100 from
+        # expected. Notifications route to self.cost_alerts_topic; each
+        # env's Chatbot subscribes to this topic to forward alerts to Slack.
+
+        self.cost_alerts_topic = sns.Topic(
+            self,
+            "CostAlertsTopic",
+            display_name="mermaid-cost-anomaly-alerts",
+            topic_name="mermaid-cost-anomaly-alerts",
+        )
+
+        cost_monitor = ce.CfnAnomalyMonitor(
+            self,
+            "CostAnomalyMonitor",
+            monitor_name="mermaid-cost-anomaly-monitor",
+            monitor_type="DIMENSIONAL",
+            monitor_dimension="SERVICE",
+        )
+
+        ce.CfnAnomalySubscription(
+            self,
+            "CostAnomalySubscription",
+            subscription_name="mermaid-cost-anomaly-alerts",
+            monitor_arn_list=[cost_monitor.attr_monitor_arn],
+            subscribers=[
+                ce.CfnAnomalySubscription.SubscriberProperty(
+                    address=self.cost_alerts_topic.topic_arn,
+                    type="SNS",
+                )
+            ],
+            threshold_expression='{"Dimensions":{"Key":"ANOMALY_TOTAL_IMPACT_ABSOLUTE","MatchOptions":["GREATER_THAN_OR_EQUAL"],"Values":["100"]}}',
+            frequency="DAILY",
         )
 
 

--- a/iac/stacks/constructs/alerts.py
+++ b/iac/stacks/constructs/alerts.py
@@ -39,6 +39,7 @@ class MonitoringAlerts(Construct):
         sagemaker_domain_name: str | None = None,
         slack_workspace_id: str | None = None,
         slack_channel_id: str | None = None,
+        cost_alerts_topic: sns.ITopic | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -437,7 +438,7 @@ class MonitoringAlerts(Construct):
                 slack_channel_configuration_name=f"mermaid-{env_id}-alerts",
                 slack_workspace_id=slack_workspace_id,
                 slack_channel_id=slack_channel_id,
-                notification_topics=[self.topic],
+                notification_topics=[self.topic] + ([cost_alerts_topic] if cost_alerts_topic else []),
                 role=slack_channel_role,
                 # Guardrail = hard ceiling on effective permissions
                 guardrail_policies=[
@@ -445,3 +446,4 @@ class MonitoringAlerts(Construct):
                     observability_policy,
                 ],
             )
+


### PR DESCRIPTION
Talked to Kim and he had cost anomaly detection on mgmt admin account which I cannot access hence we agreed on having it in the core account after the last cost spike from s3. 
https://trello.com/c/CuHjkQgc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS Cost Anomaly Detection to automatically monitor and alert on AWS spending deviations exceeding $100.
  * Cost anomaly alerts are now integrated with existing monitoring infrastructure.
  * Slack notifications now include cost alerts when Slack integration is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->