### PR TITLE
use github different envs for nags for slackbot role policy

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -27,6 +27,10 @@ jobs:
   deploy:
     needs: [call-test]
     runs-on: ubuntu-latest
+    # Tag pushes deploy prod; dev-branch pushes deploy dev. Selecting the matching
+    # GitHub Environment resolves that env's SLACK_CHANNEL_ID / SLACK_WORKSPACE_ID
+    # (and any other environment-scoped secrets); repo-level secrets still resolve.
+    environment: ${{ startsWith(github.ref, 'refs/tags') && 'prod' || 'dev' }}
     steps:
       - uses: actions/setup-node@v6.2.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,9 @@ jobs:
     uses: ./.github/workflows/_test.yml
 
   cdk-diff:
-    # environment: dev
+    # PR diffs/nag run against dev — select the dev environment so its
+    # SLACK_CHANNEL_ID / SLACK_WORKSPACE_ID resolve and the diff matches reality.
+    environment: dev
     needs: [call-test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,9 +27,11 @@ jobs:
     uses: ./.github/workflows/_test.yml
 
   cdk-diff:
-    # PR diffs/nag run against dev — select the dev environment so its
-    # SLACK_CHANNEL_ID / SLACK_WORKSPACE_ID resolve and the diff matches reality.
-    environment: dev
+    # No environment here on purpose: GitHub treats `environment:` as a deploy
+    # gate, and dev's protection rules block PR merge refs. cdk-diff is a
+    # read-only diff, so it runs un-gated. SLACK_* are repo-level secrets (dev
+    # values) so the diff is accurate; the per-env deploy jobs override them
+    # with environment secrets.
     needs: [call-test]
     runs-on: ubuntu-latest
     steps:

--- a/iac/nag_suppressions.py
+++ b/iac/nag_suppressions.py
@@ -33,6 +33,23 @@ def _suppress_by_path(
     )
 
 
+def _path_exists(stack: Stack, path: str) -> bool:
+    """True if a construct exists at `path` (slash-separated) relative to the stack.
+
+    Used to gate suppressions for *optional* resources — e.g. the Slack Chatbot
+    config, which is only created when both Slack workspace and channel IDs are
+    set. Without this guard, cdk-nag raises "suppression path did not match any
+    resource" and synth fails whenever Slack is unconfigured.
+    """
+    node = stack
+    for segment in path.split("/"):
+        child = node.node.try_find_child(segment)
+        if child is None:
+            return False
+        node = child
+    return True
+
+
 # ---------------------------------------------------------------------------
 # GithubAccessStack
 # ---------------------------------------------------------------------------
@@ -525,32 +542,36 @@ def suppress_api(stack: Stack) -> None:
     )
 
     # --- Chatbot Slack channel role ---
-    _suppress_by_path(
-        stack,
-        "Alerts/SlackChannelConfigurationRole/Resource",
-        [
-            NagPackSuppression(
-                id="AwsSolutions-IAM4",
-                reason=f"{ACCEPTED}: AmazonQDeveloperAccess is an AWS managed policy with no "
-                "customer-managed equivalent for Amazon Q Developer in Slack.",
-                applies_to=[
-                    "Policy::arn:<AWS::Partition>:iam::aws:policy/AmazonQDeveloperAccess",
-                ],
-            ),
-        ],
-    )
-    _suppress_by_path(
-        stack,
-        "Alerts/SlackObservabilityPolicy/Resource",
-        [
-            NagPackSuppression(
-                id="AwsSolutions-IAM5",
-                reason=f"{ACCEPTED}: Observability read actions (cloudwatch:Get*, ecs:List*, etc.) "
-                "operate on account-wide resources by design — CloudWatch metrics and ECS services "
-                "cannot be scoped to a single ARN without breaking Describe/List semantics.",
-            ),
-        ],
-    )
+    # The Slack Chatbot config (and its role/policy) is only created when both
+    # Slack workspace and channel IDs are configured, so gate these suppressions
+    # on the resource actually existing.
+    if _path_exists(stack, "Alerts/SlackChannelConfigurationRole/Resource"):
+        _suppress_by_path(
+            stack,
+            "Alerts/SlackChannelConfigurationRole/Resource",
+            [
+                NagPackSuppression(
+                    id="AwsSolutions-IAM4",
+                    reason=f"{ACCEPTED}: AmazonQDeveloperAccess is an AWS managed policy with no "
+                    "customer-managed equivalent for Amazon Q Developer in Slack.",
+                    applies_to=[
+                        "Policy::arn:<AWS::Partition>:iam::aws:policy/AmazonQDeveloperAccess",
+                    ],
+                ),
+            ],
+        )
+        _suppress_by_path(
+            stack,
+            "Alerts/SlackObservabilityPolicy/Resource",
+            [
+                NagPackSuppression(
+                    id="AwsSolutions-IAM5",
+                    reason=f"{ACCEPTED}: Observability read actions (cloudwatch:Get*, ecs:List*, etc.) "
+                    "operate on account-wide resources by design — CloudWatch metrics and ECS services "
+                    "cannot be scoped to a single ARN without breaking Describe/List semantics.",
+                ),
+            ],
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  Wire per-env Slack config + tolerate absent Slack in cdk-nag

  GitHub Environment secrets now hold SLACK_CHANNEL_ID / SLACK_WORKSPACE_ID
  separately for dev and prod (they previously shared repo-level secrets,
  which made dev and prod resolve the same Slack channel — AWS Chatbot
  rejects a second config for one channel per account).

  - deploy-cdk.yml: select the GitHub Environment from the ref (prod on tags,
    dev otherwise) so the job resolves that env's Slack secrets.
  - pr.yml: cdk-diff runs against dev, so pin it to the dev environment for
    accurate diffs/nag.
  - nag_suppressions.py: only apply the Slack Chatbot role/policy suppressions
    when those resources exist. The Slack config is created only when both
    Slack IDs are set; without this guard, cdk-nag fails synth with
    "suppression path did not match any resource" whenever Slack is absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved deployment pipeline with dynamic environment selection based on deployment type (production for releases, development for other updates).
  * Fixed a configuration issue where deployment could fail when optional components are not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->