### PR TITLE
summary cache waiting for recently triggered reports

### DIFF
--- a/src/api/tests/test_summary_cache_wait.py
+++ b/src/api/tests/test_summary_cache_wait.py
@@ -1,0 +1,70 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.models import SummaryCacheQueue
+from api.utils.reports import create_sample_unit_method_summary_report
+from api.utils.summary_cache import wait_for_summary_cache
+
+
+def test_wait_skips_unrelated_projects_and_returns_false():
+    """Only entries for the requested project_ids trigger a wait; others are ignored."""
+    SummaryCacheQueue.objects.create(project_id=uuid.uuid4())
+
+    with patch("api.utils.summary_cache.time") as mock_time:
+        mock_time.monotonic.return_value = 0.0
+        result = wait_for_summary_cache([uuid.uuid4()])
+
+    assert result is False
+    mock_time.sleep.assert_not_called()
+
+
+def test_wait_polls_until_entry_cleared():
+    project_id = uuid.uuid4()
+    SummaryCacheQueue.objects.create(project_id=project_id)
+    sleep_calls = [0]
+
+    def fake_sleep(_):
+        sleep_calls[0] += 1
+        if sleep_calls[0] >= 2:
+            SummaryCacheQueue.objects.filter(project_id=project_id).delete()
+
+    with (
+        patch("api.utils.summary_cache.SUMMARY_CACHE_MAX_WAIT", 30),
+        patch("api.utils.summary_cache.time.sleep", side_effect=fake_sleep),
+    ):
+        result = wait_for_summary_cache([project_id])
+
+    assert result is False
+
+
+def test_wait_times_out_logs_warning_and_returns_true():
+    project_id = uuid.uuid4()
+    SummaryCacheQueue.objects.create(project_id=project_id)
+    with (
+        patch("api.utils.summary_cache.logger") as mock_logger,
+        patch("api.utils.summary_cache.SUMMARY_CACHE_MAX_WAIT", -1),
+    ):
+        result = wait_for_summary_cache([project_id])
+    assert result is True
+    mock_logger.warning.assert_called_once()
+    assert "Timed out" in mock_logger.warning.call_args[0][0]
+
+
+@pytest.mark.parametrize("stale", [True, False])
+def test_report_passes_stale_flag_to_email(project1, stale):
+    mock_wb = MagicMock()
+    with (
+        patch("api.utils.reports.wait_for_summary_cache", return_value=stale),
+        patch("api.utils.reports.create_protocol_report", return_value=mock_wb),
+        patch("api.utils.reports.email_report") as mock_email,
+    ):
+        create_sample_unit_method_summary_report(
+            project_ids=[project1.pk],
+            protocol="fishbelt",
+            send_email="test@example.com",
+            request=MagicMock(user=MagicMock(profile=MagicMock(email="test@example.com"))),
+            wait_for_cache=True,
+        )
+    assert mock_email.call_args.kwargs.get("data_may_be_stale") is stale

--- a/src/api/tests/test_summary_cache_wait.py
+++ b/src/api/tests/test_summary_cache_wait.py
@@ -5,7 +5,7 @@ import pytest
 
 from api.models import SummaryCacheQueue
 from api.utils.reports import create_sample_unit_method_summary_report
-from api.utils.summary_cache import wait_for_summary_cache
+from api.utils.summary_cache import SUMMARY_CACHE_POLL_INTERVAL, wait_for_summary_cache
 
 
 def test_wait_skips_unrelated_projects_and_returns_false():
@@ -33,6 +33,7 @@ def test_wait_polls_until_entry_cleared():
     with (
         patch("api.utils.summary_cache.SUMMARY_CACHE_MAX_WAIT", 30),
         patch("api.utils.summary_cache.time.sleep", side_effect=fake_sleep),
+        patch("api.utils.summary_cache.connection"),
     ):
         result = wait_for_summary_cache([project_id])
 
@@ -52,14 +53,40 @@ def test_wait_times_out_logs_warning_and_returns_true():
     assert "Timed out" in mock_logger.warning.call_args[0][0]
 
 
+def test_wait_times_out_after_multiple_polls():
+    """Deadline not reached until the second check, so sleep must fire at least once."""
+    project_id = uuid.uuid4()
+    SummaryCacheQueue.objects.create(project_id=project_id)
+
+    # monotonic calls: [deadline setup, first deadline check, second deadline check]
+    # First check: 0.0 < 10.0  → sleep; second check: 999.0 >= 10.0 → timeout
+    monotonic_values = iter([0.0, 0.0, 999.0])
+
+    with (
+        patch("api.utils.summary_cache.SUMMARY_CACHE_MAX_WAIT", 10),
+        patch("api.utils.summary_cache.time.monotonic", side_effect=monotonic_values),
+        patch("api.utils.summary_cache.time.sleep") as mock_sleep,
+        patch("api.utils.summary_cache.connection"),
+        patch("api.utils.summary_cache.logger"),
+    ):
+        result = wait_for_summary_cache([project_id])
+
+    assert result is True
+    mock_sleep.assert_called_once_with(SUMMARY_CACHE_POLL_INTERVAL)
+
+
 @pytest.mark.parametrize("stale", [True, False])
 def test_report_passes_stale_flag_to_email(project1, stale):
     mock_wb = MagicMock()
+    mock_qs = MagicMock()
+    mock_qs.exists.return_value = False  # no entries in the re-check so wait's return value governs
     with (
         patch("api.utils.reports.wait_for_summary_cache", return_value=stale),
+        patch("api.utils.reports.SummaryCacheQueue") as mock_scq,
         patch("api.utils.reports.create_protocol_report", return_value=mock_wb),
         patch("api.utils.reports.email_report") as mock_email,
     ):
+        mock_scq.objects.filter.return_value = mock_qs
         create_sample_unit_method_summary_report(
             project_ids=[project1.pk],
             protocol="fishbelt",

--- a/src/api/utils/email.py
+++ b/src/api/utils/email.py
@@ -138,7 +138,7 @@ def email_project_admins(**kwargs):
         )
 
 
-def email_report(to_email, local_file_path, protocol):
+def email_report(to_email, local_file_path, protocol, data_may_be_stale=False):
     if not to_email or "@" not in to_email:
         raise ValueError("Invalid email address")
     if not local_file_path or not Path(local_file_path).is_file():
@@ -171,7 +171,11 @@ def email_report(to_email, local_file_path, protocol):
         to = [to_email]
         template = "emails/report.html"
         report_title = PROTOCOL_MAP.get(protocol) or ""
-        context = {"file_url": file_url, "title": report_title}
+        context = {
+            "file_url": file_url,
+            "title": report_title,
+            "data_may_be_stale": data_may_be_stale,
+        }
         send_mermaid_email(
             f"{report_title} Report",
             template,

--- a/src/api/utils/reports.py
+++ b/src/api/utils/reports.py
@@ -9,6 +9,7 @@ from ..reports.summary_report import create_protocol_report
 from . import create_iso_date_string, delete_file, s3
 from .email import email_report
 from .q import submit_job
+from .summary_cache import wait_for_summary_cache
 
 SAMPLE_UNIT_METHOD_REPORT_TYPE = "summary_sample_unit_method"
 GFCR_REPORT_TYPE = "gfcr"
@@ -55,6 +56,8 @@ def create_sample_unit_method_summary_report_background(
         protocol,
         request=req,
         send_email=send_email,
+        wait_for_cache=True,
+        visibility_timeout=120,
     )
 
 
@@ -63,6 +66,7 @@ def create_sample_unit_method_summary_report(
     protocol,
     request=None,
     send_email=None,
+    wait_for_cache=False,
 ):
     request = request or MockRequest()
 
@@ -72,6 +76,8 @@ def create_sample_unit_method_summary_report(
 
     if isinstance(project_ids, list) is False:
         project_ids = [project_ids]
+
+    data_may_be_stale = wait_for_summary_cache(project_ids) if wait_for_cache else False
 
     with NamedTemporaryFile(delete=False) as f:
         temppath = Path(f.name)
@@ -86,7 +92,12 @@ def create_sample_unit_method_summary_report(
             return None
 
         if send_email:
-            email_report(request.user.profile.email, output_path, protocol)
+            email_report(
+                request.user.profile.email,
+                output_path,
+                protocol,
+                data_may_be_stale=data_may_be_stale,
+            )
             delete_file(output_path)
         else:
             return output_path

--- a/src/api/utils/reports.py
+++ b/src/api/utils/reports.py
@@ -4,6 +4,7 @@ from tempfile import NamedTemporaryFile
 from django.conf import settings
 
 from ..mocks import MockRequest
+from ..models import SummaryCacheQueue
 from ..reports import attributes_report
 from ..reports.summary_report import create_protocol_report
 from . import create_iso_date_string, delete_file, s3
@@ -57,7 +58,7 @@ def create_sample_unit_method_summary_report_background(
         request=req,
         send_email=send_email,
         wait_for_cache=True,
-        visibility_timeout=120,
+        visibility_timeout=180,
     )
 
 
@@ -78,6 +79,12 @@ def create_sample_unit_method_summary_report(
         project_ids = [project_ids]
 
     data_may_be_stale = wait_for_summary_cache(project_ids) if wait_for_cache else False
+
+    # Narrow the TOCTOU window: re-check for submissions that raced in after the
+    # wait cleared but before we generate.
+    if wait_for_cache and not data_may_be_stale:
+        if SummaryCacheQueue.objects.filter(project_id__in=project_ids).exists():
+            data_may_be_stale = True
 
     with NamedTemporaryFile(delete=False) as f:
         temppath = Path(f.name)

--- a/src/api/utils/summary_cache.py
+++ b/src/api/utils/summary_cache.py
@@ -305,9 +305,8 @@ def add_project_to_queue(project_id, skip_test_project=False):
         logger.exception(f"Failed to queue summary update for project {project_id}")
 
 
-# The report job uses a 120s SQS visibility timeout; SUMMARY_CACHE_MAX_WAIT +
-# post-wait work (~30s for report generation, S3 upload, email dispatch) must
-# stay under that.
+# The report job uses a 180s SQS visibility timeout. Budget: SUMMARY_CACHE_MAX_WAIT
+# (80s) + report generation/S3/email (~30s typical, ~70s headroom for large projects).
 SUMMARY_CACHE_POLL_INTERVAL = 5  # seconds
 SUMMARY_CACHE_MAX_WAIT = 80  # seconds
 
@@ -316,6 +315,10 @@ def wait_for_summary_cache(project_ids):
     """Block until SummaryCacheQueue entries for project_ids are cleared, or timeout.
 
     Returns True if the wait timed out (data may be stale), False if all entries cleared.
+
+    Note: there is an inherent TOCTOU race — a submission queued between the final poll
+    returning empty and the caller generating the report will be missed. Callers should
+    re-check the queue immediately before generating to narrow that window.
     """
     if settings.TESTING:
         return False
@@ -336,6 +339,7 @@ def wait_for_summary_cache(project_ids):
                 pending_ids,
             )
             return True
+        connection.close()
         time.sleep(SUMMARY_CACHE_POLL_INTERVAL)
 
 

--- a/src/api/utils/summary_cache.py
+++ b/src/api/utils/summary_cache.py
@@ -1,5 +1,7 @@
 import logging
+import time
 
+from django.conf import settings
 from django.db import connection, transaction
 from django.db.utils import DataError, IntegrityError
 from django.utils import timezone
@@ -301,6 +303,40 @@ def add_project_to_queue(project_id, skip_test_project=False):
 
     except Exception:
         logger.exception(f"Failed to queue summary update for project {project_id}")
+
+
+# The report job uses a 120s SQS visibility timeout; SUMMARY_CACHE_MAX_WAIT +
+# post-wait work (~30s for report generation, S3 upload, email dispatch) must
+# stay under that.
+SUMMARY_CACHE_POLL_INTERVAL = 5  # seconds
+SUMMARY_CACHE_MAX_WAIT = 80  # seconds
+
+
+def wait_for_summary_cache(project_ids):
+    """Block until SummaryCacheQueue entries for project_ids are cleared, or timeout.
+
+    Returns True if the wait timed out (data may be stale), False if all entries cleared.
+    """
+    if settings.TESTING:
+        return False
+
+    deadline = time.monotonic() + SUMMARY_CACHE_MAX_WAIT
+    while True:
+        pending_ids = list(
+            SummaryCacheQueue.objects.filter(project_id__in=project_ids).values_list(
+                "project_id", flat=True
+            )
+        )
+        if not pending_ids:
+            return False
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "Timed out waiting for summary cache to update for projects %s. "
+                "Report may contain stale data.",
+                pending_ids,
+            )
+            return True
+        time.sleep(SUMMARY_CACHE_POLL_INTERVAL)
 
 
 @timing

--- a/src/templates/emails/report.html
+++ b/src/templates/emails/report.html
@@ -3,9 +3,14 @@
 {% block body %}
 <h2>{{title}} Report</h2>
 <p>
-    Your {{title}} report is ready for download. Please download the report from 
+    Your {{title}} report is ready for download. Please download the report from
     <strong><a href="{{file_url|safe}}">this link</a></strong>.<br>
 
     <small>Link will be valid for 7 days.</small>
 </p>
+{% if data_may_be_stale %}
+<p>
+    <small><em>Note: Summary data was still being updated when this report was generated. Some records may not reflect the most recent submissions.</em></small>
+</p>
+{% endif %}
 {% endblock %}

--- a/src/templates/emails/report.txt
+++ b/src/templates/emails/report.txt
@@ -3,8 +3,11 @@
     {{title}} Report
 
     Your {{title}} report is ready for download. Please click the link below to download the report.
-    
+
     {{file_url|safe}}
 
     Link will be valid for 7 days.
+{% if data_may_be_stale %}
+    Note: Summary data was still being updated when this report was generated. Some records may not reflect the most recent submissions.
+{% endif %}
 {% endblock %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Report emails now optionally include a “stale summary data” notice when the underlying summary cache may not be fully up to date at generation time, so recipients better understand data completeness.

* **Tests**
  * Added new pytest coverage for summary-cache freshness waiting, race-condition handling, timeout behavior, and correct propagation of the staleness flag through report generation to email delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->