### PR TITLE
healthcheck at 8081/health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,16 @@ USER ${APP_USER}:${APP_USER}
 # Call collectstatic (customize the following line with the minimal environment variables needed for manage.py to run):
 RUN SECRET_KEY='abc' python manage.py collectstatic --noinput
 
+# Container health check for the API web server. Probes the DB-independent
+# liveness path served by HealthEndpointMiddleware (returns before auth/DB), via
+# the already-installed wget. start-period covers migrations + gunicorn boot.
+#
+# Used by local Docker / `docker compose`. ECS uses the task definition's own
+# healthCheck and ignores this image-level one; the scheduled tasks
+# (ScheduledBackupTask, SummaryCacheTask) override CMD with a management command
+# and run to completion, so their health signal is the container exit code, not
+# an HTTP probe (see ticket evaluation).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8081/health/ || exit 1
+
 CMD ["/var/projects/webapp/docker-entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,6 @@ RUN SECRET_KEY='abc' python manage.py collectstatic --noinput
 # and run to completion, so their health signal is the container exit code, not
 # an HTTP probe (see ticket evaluation).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8081/health/ || exit 1
+  CMD wget --quiet --tries=1 --timeout=3 --spider http://localhost:8081/health/ || exit 1
 
 CMD ["/var/projects/webapp/docker-entry.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,12 @@ services:
     ports:
       - 8080:8080
       - 8081:8081
-    # The container idles on `tail` and the server is started manually
-    # (make runserver/:8080 or runserverplus/:8081), so the image HEALTHCHECK
-    # (probes :8081) would read unhealthy during normal dev. Disable it here;
-    # the image-level HEALTHCHECK still governs ECS/real `docker run`.
+    # Local-dev override only. The container idles on `tail` and the server is
+    # started manually (make runserver/:8080 or runserverplus/:8081), so the
+    # image HEALTHCHECK (probes :8081) would read unhealthy during normal dev.
+    # This disables it for local compose only — it still applies to a plain
+    # `docker run` of the image. ECS ignores the image HEALTHCHECK entirely and
+    # uses the task definition's healthCheck instead.
     healthcheck:
       disable: true
     command: tail -f /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,12 @@ services:
     ports:
       - 8080:8080
       - 8081:8081
+    # The container idles on `tail` and the server is started manually
+    # (make runserver/:8080 or runserverplus/:8081), so the image HEALTHCHECK
+    # (probes :8081) would read unhealthy during normal dev. Disable it here;
+    # the image-level HEALTHCHECK still governs ECS/real `docker run`.
+    healthcheck:
+      disable: true
     command: tail -f /dev/null
     env_file:
       - .env


### PR DESCRIPTION
https://trello.com/c/36IH4Me6

- Dockerfile — HEALTHCHECK confirmed in the image (wget → /health/ on :8081, 30s/5s/90s/3).
- docker-compose.yml — disabled for the idle dev container (no false "unhealthy").
- Scheduled tasks — evaluated: ECS ignores image HEALTHCHECK; run-to-completion tasks signal via exit code. No separate health needed.
- make build and tests passed; image config verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an image-level health check for the API container to verify the service is reachable at `/health/`.
  * Adjusted local container settings so development workflows won’t fail health checks while the server is started manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->