### PR TITLE
skip submit job intests

### DIFF
--- a/src/api/utils/reports.py
+++ b/src/api/utils/reports.py
@@ -21,6 +21,12 @@ REPORT_TYPES = [
 
 
 def update_attributes_report(local_output_dir=None):
+    # Skip in tests: submit_job runs inline under settings.TESTING, so every
+    # approved-attribute save would otherwise build + upload the report to S3
+    # (None bucket in CI -> TypeError; real bucket locally -> pollutes prod).
+    if settings.TESTING and local_output_dir is None:
+        return
+
     canonical_filename = "mermaid_attributes.xlsx"
     dated_filename = f"mermaid_attributes_{create_iso_date_string()}.xlsx"
 


### PR DESCRIPTION
Fixed. With AWS_PUBLIC_BUCKET unset (exact CI condition) these 8 previously-erroring tests now pass.

Summary

Why dev deploy failed: 349 test errors → 52% coverage → --cov-fail-under=80 blocked deploy.

Root cause: commit cc1d1ead added settings.TESTING = True to conftest.py. Under TESTING, submit_job runs callables inline. The refresh_attribute_views signal fires submit_job(10, True, update_attributes_report) on every approved-attribute save → so update_attributes_report now ran a real S3 upload during tests:
- CI: AWS_PUBLIC_BUCKET unset → PUBLIC_BUCKET=None → boto upload_file(Bucket=None) → s3transfer:490 TypeError → every attribute/data fixture errored.
- Local: bucket set → uploads succeeded, so tests passed — while silently pushing mermaid_attributes.xlsx to the prod public bucket on every run.

Fix (src/api/utils/reports.py): early-return from update_attributes_report when settings.TESTING and no explicit local_output_dir. Stops the CI crash and the local prod-S3 pollution. Explicit local export (local_output_dir set, e.g. management command) still works.

Not changed: the settings.TESTING=True addition and the inline-submit_job behavior are intentional — only the report's S3 side-effect was wrong to run in tests.