### PR TITLE
[M2032] change GoI weighting to equal split

### DIFF
--- a/src/api/models/sql_models/beltinvert.py
+++ b/src/api/models/sql_models/beltinvert.py
@@ -140,32 +140,35 @@ class BeltInvertSUSQLModel(BaseSUSQLModel):
             {BeltInvertObsSQLModel.sql}
         ),
         goi_weights_by_family AS MATERIALIZED (
-            SELECT ig.family_id, goi.name AS goi_name,
-                COUNT(ig.invertattribute_ptr_id)::float /
-                SUM(COUNT(ig.invertattribute_ptr_id)) OVER (PARTITION BY ig.family_id) AS weight
-            FROM invert_genus ig
-            JOIN invert_group_of_interest goi ON ig.group_of_interest_id = goi.invertattribute_ptr_id
-            GROUP BY ig.family_id, ig.group_of_interest_id, goi.name
+            SELECT family_id, goi_name,
+                1.0 / COUNT(*) OVER (PARTITION BY family_id) AS weight
+            FROM (
+                SELECT DISTINCT ig.family_id, goi.name AS goi_name
+                FROM invert_genus ig
+                JOIN invert_group_of_interest goi ON ig.group_of_interest_id = goi.invertattribute_ptr_id
+            ) distinct_family_gois
         ),
         goi_weights_by_order AS MATERIALIZED (
-            SELECT io.invertattribute_ptr_id AS order_id, goi.name AS goi_name,
-                COUNT(ig.invertattribute_ptr_id)::float /
-                SUM(COUNT(ig.invertattribute_ptr_id)) OVER (PARTITION BY io.invertattribute_ptr_id) AS weight
-            FROM invert_genus ig
-            JOIN invert_family f ON ig.family_id = f.invertattribute_ptr_id
-            JOIN invert_order io ON f.order_id = io.invertattribute_ptr_id
-            JOIN invert_group_of_interest goi ON ig.group_of_interest_id = goi.invertattribute_ptr_id
-            GROUP BY io.invertattribute_ptr_id, ig.group_of_interest_id, goi.name
+            SELECT order_id, goi_name,
+                1.0 / COUNT(*) OVER (PARTITION BY order_id) AS weight
+            FROM (
+                SELECT DISTINCT io.invertattribute_ptr_id AS order_id, goi.name AS goi_name
+                FROM invert_genus ig
+                JOIN invert_family f ON ig.family_id = f.invertattribute_ptr_id
+                JOIN invert_order io ON f.order_id = io.invertattribute_ptr_id
+                JOIN invert_group_of_interest goi ON ig.group_of_interest_id = goi.invertattribute_ptr_id
+            ) distinct_order_gois
         ),
         goi_weights_by_class AS MATERIALIZED (
-            SELECT io.invert_class_id, goi.name AS goi_name,
-                COUNT(ig.invertattribute_ptr_id)::float /
-                SUM(COUNT(ig.invertattribute_ptr_id)) OVER (PARTITION BY io.invert_class_id) AS weight
-            FROM invert_genus ig
-            JOIN invert_family f ON ig.family_id = f.invertattribute_ptr_id
-            JOIN invert_order io ON f.order_id = io.invertattribute_ptr_id
-            JOIN invert_group_of_interest goi ON ig.group_of_interest_id = goi.invertattribute_ptr_id
-            GROUP BY io.invert_class_id, ig.group_of_interest_id, goi.name
+            SELECT invert_class_id, goi_name,
+                1.0 / COUNT(*) OVER (PARTITION BY invert_class_id) AS weight
+            FROM (
+                SELECT DISTINCT io.invert_class_id, goi.name AS goi_name
+                FROM invert_genus ig
+                JOIN invert_family f ON ig.family_id = f.invertattribute_ptr_id
+                JOIN invert_order io ON f.order_id = io.invertattribute_ptr_id
+                JOIN invert_group_of_interest goi ON ig.group_of_interest_id = goi.invertattribute_ptr_id
+            ) distinct_class_gois
         ),
         obs_goi AS (
             SELECT o.pseudosu_id, goi.name AS goi_name, o.count::float AS attributed_count
@@ -183,6 +186,10 @@ class BeltInvertSUSQLModel(BaseSUSQLModel):
             JOIN invert_genus g ON o.invert_attribute_id = g.invertattribute_ptr_id
             JOIN invert_group_of_interest goi ON g.group_of_interest_id = goi.invertattribute_ptr_id
             UNION ALL
+            -- NOTE: If a family/order/class taxon has no genera with GoI assignments in the
+            -- taxonomy DB, the JOIN below produces no rows and the observation's count is
+            -- silently absent from density_indha_group_interest while still counted in
+            -- total_abundance and density_indha, making those fields inconsistent.
             SELECT o.pseudosu_id, w.goi_name, o.count * w.weight
             FROM belt_invert_obs o
             JOIN invert_family fam ON o.invert_attribute_id = fam.invertattribute_ptr_id

--- a/src/api/tests/fixtures/macroinvertebrate.py
+++ b/src/api/tests/fixtures/macroinvertebrate.py
@@ -75,6 +75,17 @@ def invert_family_1(db, invert_order_1):
 
 
 @pytest.fixture
+def invert_family_2(db, invert_order_1):
+    # A family with no genera in the DB — used to test that family-level observations
+    # whose family has no GoI-linked genera are absent from density_indha_group_interest.
+    return InvertFamily.objects.create(
+        name="Orphan family",
+        order=invert_order_1,
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
 def invert_genus_1(db, invert_family_1, invert_group_of_interest_1):
     return InvertGenus.objects.create(
         name="Strongylocentrotus",
@@ -188,6 +199,19 @@ def belt_invert1_with_obs(db, belt_invert1, invert_genus_1):
         invert_attribute=invert_genus_1,
         count=3,
         size=Decimal("2.5"),
+    )
+    return belt_invert1
+
+
+@pytest.fixture
+def belt_invert1_with_no_goi_family_obs(db, belt_invert1, invert_family_2):
+    # Family has no genera → goi_weights_by_family produces no rows for it → count
+    # contributes to total_abundance/density_indha but not density_indha_group_interest.
+    ObsBeltInvert.objects.create(
+        beltinvert=belt_invert1,
+        invert_attribute=invert_family_2,
+        count=5,
+        size=Decimal("2.0"),
     )
     return belt_invert1
 

--- a/src/api/tests/fixtures/macroinvertebrate.py
+++ b/src/api/tests/fixtures/macroinvertebrate.py
@@ -87,11 +87,24 @@ def invert_genus_1(db, invert_family_1, invert_group_of_interest_1):
 @pytest.fixture
 def invert_genus_2(db, invert_family_1, invert_group_of_interest_2):
     # Second genus in invert_family_1, mapped to a different GoI than invert_genus_1.
-    # Used to test proportional GoI weighting for family-level observations.
+    # Used to test equal-split GoI attribution for family-level observations.
     return InvertGenus.objects.create(
         name="Acanthaster",
         family=invert_family_1,
         group_of_interest=invert_group_of_interest_2,
+        status=SUPERUSER_APPROVED,
+    )
+
+
+@pytest.fixture
+def invert_genus_3(db, invert_family_1, invert_group_of_interest_1):
+    # Third genus in invert_family_1, same GoI as invert_genus_1. Makes the family
+    # 2:1 across GoI_1 vs GoI_2 so that equal-split (1/2 each) and genus-proportion
+    # (2/3 vs 1/3) produce different numbers — allowing tests to discriminate them.
+    return InvertGenus.objects.create(
+        name="Paracentrotus",
+        family=invert_family_1,
+        group_of_interest=invert_group_of_interest_1,
         status=SUPERUSER_APPROVED,
     )
 
@@ -180,11 +193,15 @@ def belt_invert1_with_obs(db, belt_invert1, invert_genus_1):
 
 
 @pytest.fixture
-def belt_invert1_with_goi_obs(db, belt_invert1, invert_genus_1, invert_genus_2, invert_family_1):
-    # invert_genus_1 -> GoI 1 ("Sea urchins"), invert_genus_2 -> GoI 2 ("COTS"), both
-    # in invert_family_1. A genus-level obs is attributed directly to its GoI; a
-    # family-level obs is split proportionally across the GoIs of the genera in
-    # that family (50/50 here, since each GoI has exactly one genus in the family).
+def belt_invert1_with_goi_obs(
+    db, belt_invert1, invert_genus_1, invert_genus_2, invert_genus_3, invert_family_1
+):
+    # invert_genus_1 and invert_genus_3 -> GoI 1 ("Sea urchins"); invert_genus_2 ->
+    # GoI 2 ("COTS"). All three are in invert_family_1, giving a 2:1 genus ratio.
+    # Equal-split sees 2 distinct GoIs → weight 0.5 each (density 1600/1000).
+    # Genus-proportion would give weights 2/3 vs 1/3 (density ~1933/~667) — so the
+    # assertions below only pass under equal-split, catching a regression to the old logic.
+    # invert_genus_3 is not directly observed; it exists only to set the 2:1 ratio.
     ObsBeltInvert.objects.create(
         beltinvert=belt_invert1,
         invert_attribute=invert_genus_1,

--- a/src/api/tests/test_sample_unit_method_se.py
+++ b/src/api/tests/test_sample_unit_method_se.py
@@ -89,9 +89,9 @@ def test_beltinvert_se_view_group_of_interest(
     invert_group_of_interest_2,
     update_summary_cache,
 ):
-    # Single pseudo-SU, so the SE average for each GoI equals its SU density:
-    # GoI 1 = 1600.0 (3 direct + half of the 10 family-level obs), GoI 2 = 1000.0
-    # (half of the 10 family-level obs).
+    # Single pseudo-SU, so the SE average equals the SU density. Family has a 2:1 genus
+    # ratio (invert_genus_3 adds a second GoI-1 genus) so these values only hold under
+    # equal-split: GoI 1 = 1600.0 (3 direct + 5 family), GoI 2 = 1000.0 (5 family).
     url = reverse("beltinvertmethod-sampleevent-list", kwargs=dict(project_pk=project1.pk))
     count, data, _ = _call(client, token1, url)
 

--- a/src/api/tests/test_sample_unit_method_su.py
+++ b/src/api/tests/test_sample_unit_method_su.py
@@ -105,7 +105,9 @@ def test_beltinvert_su_view_group_of_interest(
     update_summary_cache,
 ):
     # invert_genus_1 (count=3) attributes fully to GoI 1; invert_family_1 (count=10)
-    # splits 50/50 between GoI 1 and GoI 2 (one genus per GoI in that family).
+    # splits equally between GoI 1 and GoI 2 (2 distinct GoIs → 50/50).
+    # invert_genus_3 is a second GoI-1 genus in the family (2:1 ratio) so the
+    # expected values only hold under equal-split, not genus-proportion weighting.
     # density_indha = count / (len_surveyed * width_m) * 10000 = count * 200
     url = reverse("beltinvertmethod-sampleunit-list", kwargs=dict(project_pk=project1.pk))
     count, data, _ = _call(client, token1, url)

--- a/src/api/tests/test_sample_unit_method_su.py
+++ b/src/api/tests/test_sample_unit_method_su.py
@@ -122,6 +122,32 @@ def test_beltinvert_su_view_group_of_interest(
     assert goi_density[invert_group_of_interest_2.name] == pytest.approx(1000.0, 0.01)
 
 
+def test_beltinvert_su_view_family_no_goi(
+    client,
+    db_setup,
+    project1,
+    token1,
+    invert_belt_transect1,
+    belt_invert1_with_no_goi_family_obs,
+    invert_group_of_interest_1,
+    update_summary_cache,
+):
+    # A family-level obs whose family has no genera in the DB produces no rows in
+    # goi_weights_by_family. Even though invert_group_of_interest_1 exists, the obs
+    # count is not attributed to any GoI: all densities are 0.0, which are stripped by
+    # FILTER (WHERE density > 0), so density_indha_group_interest is NULL.
+    # The count still appears in total_abundance and density_indha.
+    # density_indha = 5 / (50 * 1) * 10000 = 1000.0
+    url = reverse("beltinvertmethod-sampleunit-list", kwargs=dict(project_pk=project1.pk))
+    count, data, _ = _call(client, token1, url)
+
+    assert count == 1
+    record = data[0]
+    assert record["total_abundance"] == 5
+    assert record["density_indha"] == pytest.approx(1000.0, 0.01)
+    assert record["density_indha_group_interest"] is None
+
+
 def test_benthicpit_su_view(
     client,
     db_setup,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated group-of-interest attribution for family, order, and class to use equal-split weighting across distinct matching names, improving consistency in reported densities.
  * Fixed an edge case where higher-level taxa could be omitted from group-of-interest density results while related abundance totals were still present.

* **Tests**
  * Expanded fixtures and revised expectations to cover equal-split scenarios and families with no genus GoI mapping.
  * Added a new test to verify correct handling when group-of-interest density should be absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->