### PR TITLE
Add Classifier Relese role permission for MLFlow

### DIFF
--- a/iac/stacks/github_access.py
+++ b/iac/stacks/github_access.py
@@ -149,6 +149,13 @@ class GithubAccessStack(Stack):
         # sagemaker-mlflow exposes no resource-level ARNs, so '*' is required;
         # the sagemaker:* MLflow-app actions let the client resolve/auth the
         # mlflow-app tracking ARN. Mirrors the SageMaker launcher role.
+        #
+        # sagemaker:CallMlflowAppApi is the data-plane action that authorizes
+        # REST calls (search_experiments, artifact-URI resolution, ...) against
+        # an mlflow-app resource. The sagemaker-mlflow:* namespace only governs
+        # the older MLflow *tracking servers*, so without CallMlflowAppApi the
+        # SigV4-signed REST calls to an mlflow-app 403 ("Request is not
+        # authorized") even though sagemaker-mlflow:* is granted.
         role.attach_inline_policy(
             iam.Policy(
                 self,
@@ -158,6 +165,7 @@ class GithubAccessStack(Stack):
                         effect=iam.Effect.ALLOW,
                         actions=[
                             "sagemaker-mlflow:*",
+                            "sagemaker:CallMlflowAppApi",
                             "sagemaker:DescribeMlflowApp",
                             "sagemaker:ListMlflowApps",
                             "sagemaker:CreatePresignedMlflowAppUrl",


### PR DESCRIPTION
The mermaid classifier has a release workflow that fetches a specific MLFlow run ID, and associates the model artifacts stored in MLFlow with the Github Release for tracking.

The ability to call MLFlow was missing, and this adds those permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer belt invert and benthic data fields, including notes and expanded taxonomy details.
  * Improved reports and exports with new columns, clearer labels, and updated email notices.
  * Added stronger CI and deployment workflows, including automated test runs and environment-aware deployment.

* **Bug Fixes**
  * Improved profile refresh handling so temporary authentication service issues no longer break requests.
  * Tightened validation around invert sizes and summary data readiness.
  * Prevented accidental removal of the last project admin and reduced duplicate alerting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->