### PR TITLE
[M1923] reject ingest rows with unknown Site/MR

### DIFF
--- a/src/api/ingest/serializers.py
+++ b/src/api/ingest/serializers.py
@@ -39,14 +39,17 @@ class CollectRecordCSVListSerializer(ListSerializer):
 
     def assign_choices(self, row, choices_sets):
         for name, field in self.child.fields.items():
-            val = field.get_value(row)
+            raw_val = field.get_value(row)
             choices = choices_sets.get(name)
             if choices is None:
                 continue
             try:
-                val = self._lower(val)
-                choices = {label.lower(): value for label, value in choices.items()}
-                row[name] = choices.get(val) or val
+                val = self._normalize(raw_val)
+                choices = {self._normalize(label): value for label, value in choices.items()}
+                # Fall back to the original (unnormalized) value, not the
+                # lowercased/stripped one, so an unresolved value still shows
+                # the user's actual input if it surfaces in an error message.
+                row[name] = choices.get(val, raw_val)
             except (ValueError, TypeError):
                 row[name] = None
 
@@ -72,9 +75,9 @@ class CollectRecordCSVListSerializer(ListSerializer):
         for name in diff_keys:
             del row[name]
 
-    def _lower(self, val):
+    def _normalize(self, val):
         if isinstance(val, str):
-            return val.lower()
+            return val.strip().lower()
         return val
 
     def _get_reverse_choices(self, field):
@@ -334,6 +337,26 @@ class CollectRecordCSVSerializer(Serializer):
             if email.lower() not in project_profiles:
                 raise ValidationError("{} doesn't exist".format(email))
         return val
+
+    def _validate_project_choice(self, choices_key, val, label):
+        # assign_choices() resolves a matching name to its id; if it didn't
+        # match, val is still the raw name from the CSV. Valid ids are cached
+        # on the instance since this runs once per row but project_choices
+        # itself is fixed for the lifetime of this (per-request) serializer.
+        cache_attr = "_valid_ids__{}".format(choices_key)
+        valid_ids = getattr(self, cache_attr, None)
+        if valid_ids is None:
+            valid_ids = set((self.project_choices.get(choices_key) or {}).values())
+            setattr(self, cache_attr, valid_ids)
+        if val not in valid_ids:
+            raise ValidationError('{} "{}" does not exist in this project'.format(label, val))
+        return val
+
+    def validate_data__sample_event__site(self, val):
+        return self._validate_project_choice("data__sample_event__site", val, "Site")
+
+    def validate_data__sample_event__management(self, val):
+        return self._validate_project_choice("data__sample_event__management", val, "Management")
 
     def validate(self, data):
         # Validate common Transect level fields

--- a/src/api/ingest/serializers.py
+++ b/src/api/ingest/serializers.py
@@ -38,6 +38,8 @@ class CollectRecordCSVListSerializer(ListSerializer):
         return {self.child.get_schemafield(k)[0]: v for k, v in row.items()}
 
     def assign_choices(self, row, choices_sets):
+        # choices_sets values are pre-normalized (see get_choices_sets) so this
+        # only needs to normalize the row value, not rebuild the choices dict.
         for name, field in self.child.fields.items():
             raw_val = field.get_value(row)
             choices = choices_sets.get(name)
@@ -45,7 +47,6 @@ class CollectRecordCSVListSerializer(ListSerializer):
                 continue
             try:
                 val = self._normalize(raw_val)
-                choices = {self._normalize(label): value for label, value in choices.items()}
                 # Fall back to the original (unnormalized) value, not the
                 # lowercased/stripped one, so an unresolved value still shows
                 # the user's actual input if it surfaces in an error message.
@@ -83,13 +84,16 @@ class CollectRecordCSVListSerializer(ListSerializer):
     def _get_reverse_choices(self, field):
         return dict((v, k) for k, v in field.choices.items())
 
+    def _normalize_choices(self, choices):
+        return {self._normalize(label): value for label, value in choices.items()}
+
     def get_choices_sets(self):
         choices = dict()
         for name, field in self.child.fields.items():
             if hasattr(field, "choices"):
-                choices[name] = self._get_reverse_choices(field)
+                choices[name] = self._normalize_choices(self._get_reverse_choices(field))
             elif hasattr(self.child, "project_choices") and name in self.child.project_choices:
-                choices[name] = self.child.project_choices[name]
+                choices[name] = self._normalize_choices(self.child.project_choices[name])
 
         return choices
 
@@ -338,16 +342,19 @@ class CollectRecordCSVSerializer(Serializer):
                 raise ValidationError("{} doesn't exist".format(email))
         return val
 
+    _valid_project_choice_ids = None
+
     def _validate_project_choice(self, choices_key, val, label):
         # assign_choices() resolves a matching name to its id; if it didn't
         # match, val is still the raw name from the CSV. Valid ids are cached
         # on the instance since this runs once per row but project_choices
         # itself is fixed for the lifetime of this (per-request) serializer.
-        cache_attr = "_valid_ids__{}".format(choices_key)
-        valid_ids = getattr(self, cache_attr, None)
+        if self._valid_project_choice_ids is None:
+            self._valid_project_choice_ids = {}
+        valid_ids = self._valid_project_choice_ids.get(choices_key)
         if valid_ids is None:
             valid_ids = set((self.project_choices.get(choices_key) or {}).values())
-            setattr(self, cache_attr, valid_ids)
+            self._valid_project_choice_ids[choices_key] = valid_ids
         if val not in valid_ids:
             raise ValidationError('{} "{}" does not exist in this project'.format(label, val))
         return val

--- a/src/api/tests/test_ingest.py
+++ b/src/api/tests/test_ingest.py
@@ -114,6 +114,51 @@ def test_fishbelt_ingest(
     assert new_records[1].data["obs_belt_fishes"][2]["fish_attribute"] == str(fish_species4.id)
 
 
+def test_fishbelt_ingest_missing_site_and_management(
+    db_setup,
+    fishbelt_file,
+    project1,
+    profile1,
+    project_profile1,
+    all_test_fish_attributes,
+    belt_transect_width_5m,
+    fish_size_bin_1,
+    tide2,
+    current2,
+    fish_species3,
+    fish_species4,
+    reef_slope1,
+    relative_depth1,
+    visibility1,
+):
+    # Note: unlike test_fishbelt_ingest, this test deliberately avoids the
+    # base_project fixture (which creates site1/site2/management1/management2),
+    # so the site/management names referenced in fishbelt_file don't exist in
+    # project1. project_profile1 is still needed so the observer email check passes.
+    new_records, ingest_output = utils.ingest(
+        protocol=FISHBELT_PROTOCOL,
+        datafile=fishbelt_file,
+        project_id=project1.pk,
+        profile_id=profile1.pk,
+        request=None,
+        dry_run=False,
+        clear_existing=False,
+        bulk_validation=False,
+        bulk_submission=False,
+        validation_suppressants=None,
+        serializer_class=None,
+    )
+
+    assert new_records is None
+    assert "errors" in ingest_output
+
+    errors = ingest_output["errors"]
+    assert len(errors) > 0
+    error_fields = {field for error in errors for field in error}
+    assert "data__sample_event__site" in error_fields
+    assert "data__sample_event__management" in error_fields
+
+
 def test_benthicpit_ingest(
     db_setup,
     benthicpit_file,


### PR DESCRIPTION
- CSV ingest (via mermaidr or the API directly) previously let a row through even when its Site/Management name didn't exist in the target project — the row saved with a blank Site/MR instead of failing, contrary to the documented "must be defined before ingestion" contract.
- Adds validate_data__sample_event__site/management to CollectRecordCSVSerializer, mirroring the existing validate_data__observers check, applying to all 7 protocols (fishbelt, benthiclit, benthicpit, benthicpqt, habitatcomplexity, bleaching, macroinvertebrate).
- Fixes a latent whitespace-matching bug in the name-resolution helper (_lower → _normalize, now strips too) so the new strict check doesn't false-reject legitimate names with incidental leading/trailing spaces.
- Error messages now include the offending value; valid-ID lookups are cached per serializer instance (O(1) per row instead of O(n)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV ingest matching so incoming values are trimmed and compared more reliably.
  * When an imported value can’t be matched, it now keeps the original input instead of altering it unexpectedly.
  * Added project-specific validation for sample event site and management values, with clear errors when they don’t exist for the current project.

* **Tests**
  * Added coverage for ingesting records with missing site and management values to verify validation errors are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->