### PR TITLE
Provision prod inference Lambda stack

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -104,7 +104,8 @@ jobs:
             mermaid-cloudtrail \
             "mermaid-guardduty-us-east-1" \
             prod-mermaid-api-django \
-            prod-mermaid-static-site
+            prod-mermaid-static-site \
+            prod-mermaid-inference
 
 
 

--- a/docs/deploy-classifier-version.md
+++ b/docs/deploy-classifier-version.md
@@ -84,21 +84,27 @@ to the ECR repo `mermaid-inference-pyspacer` tagged **`vN-K`**.
 
 ## Step 3 — Point the Lambda at the new image
 
-The Lambda's image tag is pinned in this repo's CDK config — building the image
-in step 2 does **not** by itself update the running Lambda. Bump the tag and
-deploy:
+The Lambda's image tag is pinned in this repo's CDK config **per environment**
+(`InferenceSettings.image_tag`) — building the image in step 2 does **not** by
+itself update any running Lambda. Roll the tag out dev-first, then prod; each
+environment has its own settings file and its own stack
+(`dev-mermaid-inference` / `prod-mermaid-inference`).
 
-1. Edit [`iac/settings/dev.py`](../iac/settings/dev.py) and set the inference
-   image tag to the `vN-K` from step 2:
+1. **Dev.** Edit [`iac/settings/dev.py`](../iac/settings/dev.py), set the
+   inference image tag to the `vN-K` from step 2, and merge to `dev` (via PR):
 
    ```python
    inference=InferenceSettings(image_tag="v3-2"),
    ```
 
-2. Commit the change to `dev` (via PR).
-3. Run **[Deploy CDK](https://github.com/data-mermaid/mermaid-api/actions/workflows/deploy-cdk.yml)**.
-   Deploying `InferenceStack` updates `PyspacerInferenceFunction` to serve the
-   new image. Git history of `dev.py` is the deploy log.
+   Merging to `dev` triggers **[Deploy CDK](https://github.com/data-mermaid/mermaid-api/actions/workflows/deploy-cdk.yml)**,
+   which updates `dev-mermaid-inference`'s `PyspacerInferenceFunction` to serve
+   the new image. Validate on dev.
 
-Once the deploy completes, the inference Lambda serves the new classifier
-version.
+2. **Prod.** Make the same edit in
+   [`iac/settings/prod.py`](../iac/settings/prod.py), merge it to `dev`, then cut
+   a release tag (e.g. `v1.2`). The tag triggers the **Deploy CDK** PROD job,
+   which updates `prod-mermaid-inference` the same way.
+
+Git history of `dev.py` / `prod.py` is the deploy log. Once the prod deploy
+completes, the production inference Lambda serves the new classifier version.

--- a/docs/deploy-classifier-version.md
+++ b/docs/deploy-classifier-version.md
@@ -1,0 +1,104 @@
+# Deploying a new classifier version
+
+How to release a new coral-image classifier and cut it over to the production
+inference Lambda. This is the **steady-state** procedure for after the API is
+fully cut over to the classifier pipeline (mermaid-classifier
+[#54](https://github.com/data-mermaid/mermaid-classifier/issues/54)).
+
+Three GitHub Actions, run in order, across three repos:
+
+| # | Repo | Workflow | What it does |
+|---|------|----------|--------------|
+| 1 | [`mermaid-classifier`](https://github.com/data-mermaid/mermaid-classifier) | [Release classifier version](https://github.com/data-mermaid/mermaid-classifier/actions/workflows/release.yml) | Exports the model from MLflow to `s3://mermaid-config/classifier/vN/` and cuts release `vN`. |
+| 2 | [`mermaid-inference`](https://github.com/data-mermaid/mermaid-inference) | [Build and push inference image](https://github.com/data-mermaid/mermaid-inference/actions/workflows/build-push.yml) | Builds the Lambda container image and pushes it to ECR as `vN-K`. |
+| 3 | [`mermaid-api`](https://github.com/data-mermaid/mermaid-api) (this repo) | [Deploy CDK](https://github.com/data-mermaid/mermaid-api/actions/workflows/deploy-cdk.yml) | Points the inference Lambda at the new image `vN-K`. |
+
+**Versioning:** `vN` is the **model version** — bump it (`v2` → `v3`) for a
+retrain. `K` is the **serving build** under a model version — bump it (`v3-1` →
+`v3-2`) for a code/library fix that reuses the same model. Both the release tag
+and the ECR repo are **immutable**: re-running an existing `vN` or re-pushing an
+existing `vN-K` fails, so always move to a fresh number.
+
+---
+
+## Prerequisites
+
+- A trained model registered in MLflow that you want to release.
+- The next version numbers decided: a new `vN` for a retrain, or the existing
+  `vN` with the next `K` for a code/library fix.
+- Permission to run `workflow_dispatch` workflows in all three repos.
+
+## Find the MLflow model ID
+
+Step 1 needs the MLflow **logged-model ID** (an `m-…` string), which is not
+surfaced in the MERMAID API and is awkward to find in the MLflow UI. Resolve it
+from the registered **model name + registry version** with the MLflow client.
+From a [`mermaid-classifier`](https://github.com/data-mermaid/mermaid-classifier)
+checkout (it has MLflow via the `training` extra):
+
+```bash
+MLFLOW_TRACKING_URI=<tracking-uri> \
+  uv run --extra training python -c \
+  "from mlflow import MlflowClient; print(MlflowClient().get_model_version('<model-name>', '<registry-version>').model_id)"
+# prints e.g. m-1a2b3c...   <- paste this into the release workflow's mlflow_model_id
+```
+
+`<registry-version>` is the integer version in the MLflow model registry (e.g.
+`3`) — this is **not** the same as the release `vN` you choose in step 1.
+
+---
+
+## Step 1 — Release the classifier artifact
+
+Run **[Release classifier version](https://github.com/data-mermaid/mermaid-classifier/actions/workflows/release.yml)**
+in `mermaid-classifier` (`workflow_dispatch`) with:
+
+| Input | Value |
+|-------|-------|
+| `mlflow_model_id` | the `m-…` ID from above |
+| `version` | the release tag, e.g. `v3` |
+
+It exports and re-validates `model.pt` + `model.json`, pushes them to
+`s3://mermaid-config/classifier/vN/`, and cuts GitHub release **`vN`**. The
+MLflow tracking URI and AWS role are preconfigured repo secrets — no extra
+arguments needed.
+
+> Versions are immutable — re-running an existing `vN` fails. See
+> [Releasing a classifier version](https://github.com/data-mermaid/mermaid-classifier#releasing-a-classifier-version)
+> in the classifier README for details.
+
+## Step 2 — Build and push the inference image
+
+Run **[Build and push inference image](https://github.com/data-mermaid/mermaid-inference/actions/workflows/build-push.yml)**
+in `mermaid-inference` (`workflow_dispatch`) with:
+
+| Input | Value |
+|-------|-------|
+| `model_version` | the same `vN` from step 1, e.g. `v3` |
+| `build` | the serving build number `K`, starting at `1` |
+| `classifier_ref` | the `mermaid-classifier` git tag from step 1, e.g. `v3` |
+
+It builds the `pyspacer-function` Lambda image (baking in
+`CLASSIFIER_VERSION=vN` and pinning the matching pyspacer/sklearn) and pushes it
+to the ECR repo `mermaid-inference-pyspacer` tagged **`vN-K`**.
+
+## Step 3 — Point the Lambda at the new image
+
+The Lambda's image tag is pinned in this repo's CDK config — building the image
+in step 2 does **not** by itself update the running Lambda. Bump the tag and
+deploy:
+
+1. Edit [`iac/settings/dev.py`](../iac/settings/dev.py) and set the inference
+   image tag to the `vN-K` from step 2:
+
+   ```python
+   inference=InferenceSettings(image_tag="v3-2"),
+   ```
+
+2. Commit the change to `dev` (via PR).
+3. Run **[Deploy CDK](https://github.com/data-mermaid/mermaid-api/actions/workflows/deploy-cdk.yml)**.
+   Deploying `InferenceStack` updates `PyspacerInferenceFunction` to serve the
+   new image. Git history of `dev.py` is the deploy log.
+
+Once the deploy completes, the inference Lambda serves the new classifier
+version.

--- a/iac/README.md
+++ b/iac/README.md
@@ -30,6 +30,10 @@ You can run a `cdk diff` from this directory and see the changes that will be ap
 
 This should be handled through the CI/CD configuration.
 
+## Deploying a new Classifier Model
+
+[Detailed Instructions](docs/deploy-classifier-version.md)
+
 ## cdk-nag
 
 [cdk-nag](https://github.com/cdklabs/cdk-nag) runs `AwsSolutionsChecks` during every `cdk synth`. It validates all stacks against the [AWS Solutions](https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#awssolutions) rule pack and **fails synthesis if there are unsuppressed errors**.

--- a/iac/app.py
+++ b/iac/app.py
@@ -137,6 +137,24 @@ prod_api_stack = ApiStack(
     cost_alerts_topic=common_stack.cost_alerts_topic,
 )
 
+# The pyspacer inference compute lane for prod (mermaid-classifier #53, #55).
+# Mirrors dev-mermaid-inference: a container Lambda serving the same shared
+# mermaid-inference-pyspacer image (config.inference.image_tag) already in ECR.
+# Groundwork only — it creates the function + alarms and changes nothing in the
+# prod API (no lane router / settings wired here); alarms publish to prod
+# ApiStack's shared alerts topic.
+prod_inference_stack = InferenceStack(
+    app,
+    "prod-mermaid-inference",
+    env=cdk_env,
+    tags=tags,
+    config=PROD_SETTINGS,
+    inference_repo=common_stack.inference_repo,
+    config_bucket=common_stack.config_bucket,
+    image_bucket=common_stack.image_processing_bucket,
+    alerts_topic=prod_api_stack.alerts_topic,
+)
+
 cloudtrail_stack = CloudTrailStack(
     app,
     "mermaid-cloudtrail",
@@ -190,6 +208,7 @@ nag_suppressions.apply_all(
     cloudtrail_stack=cloudtrail_stack,
     guardduty_stack=guardduty_stack,
     dev_inference_stack=dev_inference_stack,
+    prod_inference_stack=prod_inference_stack,
 )
 
 app.synth()

--- a/iac/app.py
+++ b/iac/app.py
@@ -137,12 +137,8 @@ prod_api_stack = ApiStack(
     cost_alerts_topic=common_stack.cost_alerts_topic,
 )
 
-# The pyspacer inference compute lane for prod (mermaid-classifier #53, #55).
-# Mirrors dev-mermaid-inference: a container Lambda serving the same shared
-# mermaid-inference-pyspacer image (config.inference.image_tag) already in ECR.
-# Groundwork only — it creates the function + alarms and changes nothing in the
-# prod API (no lane router / settings wired here); alarms publish to prod
-# ApiStack's shared alerts topic.
+# The pyspacer inference compute lane for prod.
+# Alarms publish to prod ApiStack's shared alerts topic.
 prod_inference_stack = InferenceStack(
     app,
     "prod-mermaid-inference",

--- a/iac/nag_suppressions.py
+++ b/iac/nag_suppressions.py
@@ -979,6 +979,7 @@ def apply_all(
     cloudtrail_stack: Stack | None = None,
     guardduty_stack: Stack | None = None,
     dev_inference_stack: Stack | None = None,
+    prod_inference_stack: Stack | None = None,
 ) -> None:
     suppress_github_access(gh_access_stack)
     suppress_common(common_stack)
@@ -1000,3 +1001,5 @@ def apply_all(
     # is not instantiated until its image exists in ECR (see app.py).
     if dev_inference_stack is not None:
         suppress_inference(dev_inference_stack)
+    if prod_inference_stack is not None:
+        suppress_inference(prod_inference_stack)

--- a/iac/settings/prod.py
+++ b/iac/settings/prod.py
@@ -1,6 +1,6 @@
 """Settings for production environment"""
 
-from settings.settings import DatabaseSettings, DjangoSettings, ProjectSettings
+from settings.settings import DatabaseSettings, DjangoSettings, InferenceSettings, ProjectSettings
 import os
 
 PROD_ENV_ID = "prod"
@@ -36,4 +36,5 @@ PROD_SETTINGS = ProjectSettings(
         slack_workspace_id=os.getenv("SLACK_WORKSPACE_ID", ""),
         slack_channel_id=os.getenv("SLACK_CHANNEL_ID", ""),
     ),
+    inference=InferenceSettings(image_tag="v2-1"),
 )


### PR DESCRIPTION
## Summary

Mirrors the dev inference Lambda (PRs #717/#722) into prod as `prod-mermaid-inference`, laying the infra groundwork **without touching the prod API**. The prod API keeps its current in-process path; this just creates the function so it's ready before any API-side cutover (some overlap with data-mermaid/mermaid-classifier#55, deliberately separated).

Unlike dev, this is a **single PR** — the shared ECR repo, OIDC push role (both in `CommonStack`/`GithubAccess`, already deployed prod-side), and the `v2-1` image already exist, so no PR1/PR2 staging is needed.

## Changes

- `iac/app.py` — instantiate `prod-mermaid-inference` (`PROD_SETTINGS`, prod ApiStack alerts topic) and register it in `apply_all`.
- `iac/settings/prod.py` — add `inference=InferenceSettings(image_tag="v2-1")`.
- `iac/nag_suppressions.py` — apply the existing `suppress_inference` to the prod stack.
- `.github/workflows/deploy-cdk.yml` — add `prod-mermaid-inference` to the PROD (tag) deploy.

## Validation

`cdk synth prod-mermaid-inference` succeeds; cdk-nag reports **0 findings**. Template is correctly prod-scoped (`MERMAID/prod/Inference`, `mermaid-prod-inference-*` alarms → prod ApiStack alerts topic).

Refs #53, #55.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying an additional production inference environment.
  * Production settings now include a pinned inference image version for consistent releases.

* **Documentation**
  * Added step-by-step guidance for releasing a new classifier version and updating the production inference deployment.
  * Expanded infrastructure docs with a link to the new release instructions.

* **Chores**
  * Updated the production deployment workflow to include the new inference stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->