### PR TITLE
Reduce alarm noise: ALB p99→p95, zero-downtime API deploy

### DIFF
--- a/iac/stacks/api.py
+++ b/iac/stacks/api.py
@@ -325,7 +325,12 @@ class ApiStack(Stack):
             security_groups=[container_security_group],
             desired_count=config.api.container_count,
             enable_execute_command=True,
-            min_healthy_percent=0,
+            # Zero-downtime rolling deploy: keep the old task serving until the new
+            # one is healthy, then drain it. Avoids the 0-running-tasks window that
+            # otherwise fires mermaid-{env}-ecs-no-running-tasks on every deploy.
+            # Needs room for one extra API task during a deploy (cluster has it).
+            min_healthy_percent=100,
+            max_healthy_percent=200,
             capacity_provider_strategies=cluster.default_capacity_provider_strategy,
             circuit_breaker=ecs.DeploymentCircuitBreaker(enable=True, rollback=True),
         )
@@ -515,9 +520,9 @@ class ApiStack(Stack):
             slack_workspace_id=config.api.slack_workspace_id or None,
             slack_channel_id=config.api.slack_channel_id or None,
             cost_alerts_topic=cost_alerts_topic,
-            # dev is low-traffic: p99 = the single slowest request, so a lone slow
-            # probe trips a 5s threshold. Relax dev; keep prod strict.
-            p99_latency_threshold=5 if config.env_id == "prod" else 10,
+            # dev is low-traffic: p95 = a single slow request among few, so a lone
+            # slow probe trips a 5s threshold. Relax dev; keep prod strict.
+            p95_latency_threshold=5 if config.env_id == "prod" else 10,
             # RDS instance is shared across envs — only prod owns its alarms to
             # avoid both envs paging on the same instance event.
             monitor_shared_rds=config.env_id == "prod",

--- a/iac/stacks/constructs/alerts.py
+++ b/iac/stacks/constructs/alerts.py
@@ -40,7 +40,7 @@ class MonitoringAlerts(Construct):
         slack_workspace_id: str | None = None,
         slack_channel_id: str | None = None,
         cost_alerts_topic: sns.ITopic | None = None,
-        p99_latency_threshold: float = 5,
+        p95_latency_threshold: float = 5,
         monitor_shared_rds: bool = True,
         **kwargs,
     ) -> None:
@@ -80,13 +80,13 @@ class MonitoringAlerts(Construct):
             cw.Alarm(
                 self,
                 "AlbLatencyAlarm",
-                alarm_name=f"mermaid-{env_id}-alb-p99-latency",
-                alarm_description=f"ALB p99 response latency exceeded {p99_latency_threshold} seconds",
+                alarm_name=f"mermaid-{env_id}-alb-p95-latency",
+                alarm_description=f"ALB p95 response latency exceeded {p95_latency_threshold} seconds",
                 metric=load_balancer.metrics.target_response_time(
-                    statistic="p99",
+                    statistic="p95",
                     period=Duration.minutes(5),
                 ),
-                threshold=p99_latency_threshold,
+                threshold=p95_latency_threshold,
                 evaluation_periods=2,
                 comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
                 treat_missing_data=cw.TreatMissingData.NOT_BREACHING,


### PR DESCRIPTION
Two changes on this branch, both to reduce Slack alarm noise:

1. ALB latency alarm: p99 → p95

iac/stacks/constructs/alerts.py + iac/stacks/api.py
- Renamed param p99_latency_threshold → p95_latency_threshold, statistic p99 → p95, alarm name mermaid-{env}-alb-p99-latency → -p95-latency, description + caller comment updated.
- Thresholds unchanged: 5s prod / 10s dev.
- p95 ignores the slowest ~5% instead of ~1%, so a lone slow request no longer trips the alarm.
- On deploy: old alarm deleted, new -p95-latency alarm created.

2. API ECS service: zero-downtime deploy

iac/stacks/api.py — min_healthy_percent=0 → min_healthy_percent=100 + max_healthy_percent=200.
- Root-cause fix for mermaid-{env}-ecs-no-running-tasks: the single API task (container_count=1) was stopped-then-started each deploy, hitting 0 running tasks → firing the alarm on every deploy.
- Now ECS keeps the old task serving until the new one is healthy, then drains → RunningTaskCount never hits 0 → no deploy pages, and no per-deploy API downtime.
- Needs room for one extra API task mid-deploy (cluster has headroom: 6 instances / 8 tasks). Circuit breaker + rollback unchanged.

Both surface as resource updates in cdk diff (two renamed alarms + one ECS service deployment-config change). No app code touched.

<img width="644" height="378" alt="image" src="https://github.com/user-attachments/assets/f43dcbdc-8a10-447d-ba9e-85e64461614c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service deployments to better support zero-downtime updates, keeping the existing version running until the new one is ready.
  * Updated API latency monitoring to alert on p95 latency instead of p99, making performance alerts more responsive to typical user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->