### PR TITLE
fix sentry sampling

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -103,6 +103,9 @@ DEV_EMAILS = [email.strip() for email in _dev_emails.split(",")]
 
 _allowed_hosts = os.environ.get("ALLOWED_HOSTS") or ""
 ALLOWED_HOSTS = [host.strip() for host in _allowed_hosts.split(",")]
+# In-container health probes hit http://localhost:8081/health/ (Host: localhost).
+# Allow it so it doesn't raise DisallowedHost on every probe.
+ALLOWED_HOSTS += ["localhost", "127.0.0.1"]
 
 # Look for Fargate IP, for health checks.
 METADATA_URI = os.getenv("ECS_CONTAINER_METADATA_URI", None)
@@ -320,6 +323,12 @@ def _sentry_before_send(event, hint):
 
 
 if ENVIRONMENT in ("dev", "prod"):
+    from sentry_sdk.integrations.logging import ignore_logger
+
+    # DisallowedHost is unactionable noise (health probes + bots with bogus Host
+    # headers) and was the top error by volume, blowing the Sentry error quota.
+    ignore_logger("django.security.DisallowedHost")
+
     sentry_sdk.init(
         dsn=os.environ.get("SENTRY_DSN"),
         environment=ENVIRONMENT,


### PR DESCRIPTION
  Problem

  Sentry was hitting its quota and rate-limiting mermaid-api events. Org usage showed mermaid-api at ~26K events with only ~5K accepted and ~21K rate-limited.

  Investigation (sentry-cli + Sentry API)

  1. List projects to get IDs/slugs:
  ```
  sentry-cli projects --org wildlife-conservation-socie-rv list
  # mermaid-api → id 4509708808355840
```
  2. Usage by category + outcome (30d) — find which quota is actually blown:
```  
ORG=wildlife-conservation-socie-rv; PID=4509708808355840
  TOK=$(python3 -c "import configparser,os;c=configparser.ConfigParser();c.read(os.path.expanduser('~/.sentryclirc'));print(c.get('auth','token',fallback=''))")
  curl -s -H "Authorization: Bearer $TOK" \
    "https://sentry.io/api/0/organizations/$ORG/stats_v2/?field=sum(quantity)&groupBy=category&groupBy=outcome&statsPeriod=30d&project=$PID" \
  | jq -r '.groups[] | [.by.category, .by.outcome, .totals["sum(quantity)"]] | @tsv' | sort -k3 -rn
  Key rows:

  span         accepted        2576852
  transaction  client_discard   740429   ← traces_sampler working (dropped client-side)
  error        rate_limited      64951   ← the problem
  transaction  accepted          49292
  error        accepted           4991
  profile      rate_limited       3901
  ```

→ Errors are the exhausted quota (65K rate-limited, 5K accepted). Transactions/spans are fine — traces_sampler is already discarding them client-side. So the "sampling not applied" hunch was a red herring for transactions; the gap is that errors have no sampling.

3. Top error issues by frequency (14d):
```
ORG=wildlife-conservation-socie-rv; PROJ=mermaid-api
TOK=$(python3 -c "import configparser,os;c=configparser.ConfigParser();c.read(os.path.expanduser('~/.sentryclirc'));print(c.get('auth','token',fallback=''))")
curl -s -G -H "Authorization: Bearer $TOK" \
  "https://sentry.io/api/0/projects/$ORG/$PROJ/issues/" \
  --data-urlencode "query=is:unresolved level:error" \
  --data-urlencode "sort=freq" \
  --data-urlencode "statsPeriod=14d" \
  --data-urlencode "limit=25" \
| jq -r 'if type=="array" then (.[] | [.count, .type, (.culprit // ""), (.metadata.value // .title)] | @tsv) else (.|tostring) end'
Output:
4959  error  /health/                                    Invalid HTTP_HOST header: 'localhost:8081'. ... add 'localhost' to ALLOWED_HOSTS.
453   error  api.covariates in update_site_aca_covariates  insert or update ... violates foreign key constraint "api_covariate_site_id..."
58    error  api.utils.project in _create_annotations_file_job  Image matching query does not exist.
```
→ One issue dominates: DisallowedHost for localhost:8081 on /health/ (~5K/14d). An in-container health probe hits localhost:8081, localhost isn't in ALLOWED_HOSTS, Django raises DisallowedHost, and django.security.DisallowedHost logs it → a Sentry error on every probe.

Fix (src/app/settings.py)

1. Allow the health probe — added localhost + 127.0.0.1 to ALLOWED_HOSTS, so the probe no longer raises DisallowedHost at the source.
2. Silence the noise in Sentry — ignore_logger("django.security.DisallowedHost") before sentry_sdk.init, so these never become Sentry events regardless of source (also drops bot probes with bogus Host headers).

No blanket error sample_rate added — once the dominant noise is gone it isn't needed, and it would cost error fidelity.

Verification
```
docker exec -i -e ENV=dev api_service python -c "import django,os; \
  os.environ.setdefault('DJANGO_SETTINGS_MODULE','app.settings'); django.setup(); \
  from django.conf import settings; print('localhost allowed:', 'localhost' in settings.ALLOWED_HOSTS)"
# localhost allowed: True
```
Not addressed (separate, real errors)

- update_site_aca_covariates FK violation on api_covariate.site_id (453) — likely a data/ordering bug.
- _create_annotations_file_job Image DoesNotExist (58).

Takes effect on next deploy (settings change).