### PR TITLE
Allow 0 for number_of_solutions_supported_by

### DIFF
--- a/src/api/resources/gfcr.py
+++ b/src/api/resources/gfcr.py
@@ -179,13 +179,9 @@ class GFCRFinanceSolutionSerializer(BaseAPISerializer):
         if type_val not in ("business", "financial_mechanism"):
             data["gender_smart"] = False
 
-        # number_of_solutions_supported_by: TAF, CTF, and Financial facility — must be > 0.
+        # number_of_solutions_supported_by: TAF, CTF, and Financial facility only.
         if type_val not in ("taf", "ctf", "financial_facility"):
             data["number_of_solutions_supported_by"] = 0
-        elif (data.get("number_of_solutions_supported_by") or 0) == 0:
-            errors[
-                "number_of_solutions_supported_by"
-            ] = "number_of_solutions_supported_by must be > 0"
 
         # sustainable_finance_mechanisms: only Financial mechanism.
         if type_val != "financial_mechanism":

--- a/src/api/scripts/simulate_gfcr_phase3.py
+++ b/src/api/scripts/simulate_gfcr_phase3.py
@@ -8,8 +8,8 @@ What it does:
   1. Normalizes indicator set titles to valid TITLE_CHOICES values.
   2. Assigns an fs_type to every finance solution, cycling through all six types so
      every coercion path is exercised at least once. Required fields for each type
-     (sector for business, geographical_coverage for ctf, number_of_solutions_supported_by
-     for taf) are pre-filled with safe defaults before the coercion runs.
+     (sector for business, geographical_coverage for ctf) are pre-filled with safe
+     defaults before the coercion runs.
   3. Replaces deprecated choice values (fm_* sectors → ce_other, removed SFMs dropped,
      public_budget investment type → grant).
   4. All finance solution changes go through GFCRFinanceSolutionSerializer.validate() so
@@ -129,8 +129,6 @@ def _assign_types(log, errors):
         num = fs.number_of_solutions_supported_by
         if fs_type == "business" and not sector:
             sector = "ce_other"
-        elif fs_type in ("taf", "ctf", "financial_facility") and num == 0:
-            num = 1
 
         data = {
             "fs_type": fs_type,

--- a/src/api/tests/test_gfcr.py
+++ b/src/api/tests/test_gfcr.py
@@ -479,25 +479,6 @@ _FS_BASE = {
         ({"fs_type": "business", "sector": ""}, "sector"),
         # geographical_coverage is required for CTF — no value to coerce to
         ({"fs_type": "ctf", "geographical_coverage": ""}, "geographical_coverage"),
-        # number_of_solutions_supported_by must be > 0 for TAF — no value to coerce to
-        (
-            {"fs_type": "taf", "number_of_solutions_supported_by": 0},
-            "number_of_solutions_supported_by",
-        ),
-        # same constraint applies to CTF (geographical_coverage supplied to avoid that error)
-        (
-            {
-                "fs_type": "ctf",
-                "geographical_coverage": "national",
-                "number_of_solutions_supported_by": 0,
-            },
-            "number_of_solutions_supported_by",
-        ),
-        # same constraint applies to Financial facility
-        (
-            {"fs_type": "financial_facility", "number_of_solutions_supported_by": 0},
-            "number_of_solutions_supported_by",
-        ),
     ],
 )
 def test_finance_solution_validate_errors(
@@ -565,6 +546,26 @@ def test_finance_solution_validate_errors(
             "number_of_solutions_supported_by",
             0,
         ),
+        # 0 is a valid, saveable value for TAF/CTF/Financial facility — not coerced away
+        (
+            {"fs_type": "taf", "number_of_solutions_supported_by": 0},
+            "number_of_solutions_supported_by",
+            0,
+        ),
+        (
+            {
+                "fs_type": "ctf",
+                "geographical_coverage": "national",
+                "number_of_solutions_supported_by": 0,
+            },
+            "number_of_solutions_supported_by",
+            0,
+        ),
+        (
+            {"fs_type": "financial_facility", "number_of_solutions_supported_by": 0},
+            "number_of_solutions_supported_by",
+            0,
+        ),
         # sustainable_finance_mechanisms cleared for non-Financial mechanism types
         (
             {"fs_type": "business", "sustainable_finance_mechanisms": ["blue_bonds"]},
@@ -594,6 +595,29 @@ def test_finance_solution_validate_coercion(
         response.status_code == 200
     ), f"Expected 200, got {response.status_code}: {response.json()}"
     assert response.json()["finance_solutions"][0][coerced_field] == expected_value
+
+
+@pytest.mark.parametrize("fs_type", ["taf", "ctf", "financial_facility"])
+@pytest.mark.parametrize("bad_value", [None, ""])
+def test_finance_solution_number_of_solutions_rejects_null_and_blank(
+    db_setup, api_client1, project1, project_profile1, indicator_set, fs_type, bad_value
+):
+    # 0 is valid (see test_finance_solution_validate_coercion), but null/"" are still
+    # rejected by DRF's default IntegerField behavior on a non-nullable model field.
+    project1.includes_gfcr = True
+    project1.save()
+    fs = {
+        **_FS_BASE,
+        "fs_type": fs_type,
+        "geographical_coverage": "national",
+        "number_of_solutions_supported_by": bad_value,
+    }
+    url = reverse("indicatorset-detail", kwargs={"project_pk": project1.pk, "pk": indicator_set.id})
+    response = api_client1.put(
+        url, data=_fs_put_payload(indicator_set, project1, fs), format="json"
+    )
+    assert response.status_code == 400
+    assert "number_of_solutions_supported_by" in str(response.json())
 
 
 def test_finance_solution_normalizes_empty_strings_for_hidden_fields(

--- a/src/tools/management/commands/check_gfcr_data.py
+++ b/src/tools/management/commands/check_gfcr_data.py
@@ -389,20 +389,6 @@ class Command(BaseCommand):
                     )
 
                 if (
-                    fs_type in ("taf", "ctf", "financial_facility")
-                    and has_num
-                    and getattr(fs, "number_of_solutions_supported_by", 0) == 0
-                ):
-                    yield (
-                        pname,
-                        name,
-                        "finance_solutions",
-                        "FS-11",
-                        "Set number of solutions supported (required for TAF, CTF, and Financial facility)",
-                        "fs_cross",
-                    )
-
-                if (
                     fs_type not in ("taf", "ctf", "financial_facility")
                     and has_num
                     and getattr(fs, "number_of_solutions_supported_by", 0) != 0


### PR DESCRIPTION
## Summary
- Cherry-pick of bca2d2da from M2040/dev — fixes GFCR validation incorrectly rejecting 0 for number_of_solutions_supported_by
- Targeted fix only; does not bring in the rest of dev's unreleased changes

## Test plan
- [ ] Confirm existing GFCR tests pass (test_gfcr.py)
- [ ] Manually verify saving a facility/solution with 0 for number_of_solutions_supported_by succeeds in prod after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Finance solutions of supported types can now validly report zero supported solutions.
  * Invalid blank or missing values continue to be rejected.
  * Data checks now flag non-zero solution counts only for unsupported finance solution types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->