### PR TITLE
[M2067] retry CR save/delete to avoid deadlocks

### DIFF
--- a/src/api/submission/utils.py
+++ b/src/api/submission/utils.py
@@ -1,8 +1,10 @@
 import json
 import logging
+import time
 
 from django.core.exceptions import ValidationError as DJValidationError
 from django.db import transaction
+from django.db.utils import OperationalError
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
 from rest_framework.exceptions import ValidationError
@@ -49,7 +51,15 @@ SUCCESS_STATUS = 200
 VALIDATION_ERROR_STATUS = 400
 ERROR_STATUS = 500
 
+# See write_collect_record() for why deadlocks get retried.
+DEADLOCK_MAX_RETRIES = 3
+DEADLOCK_RETRY_DELAY = 0.25  # seconds; multiplied by attempt number
+
 logger = logging.getLogger(__name__)
+
+
+def _is_deadlock_error(err):
+    return isinstance(err, OperationalError) and "deadlock detected" in str(err).lower()
 
 
 def get_writer(collect_record, context):
@@ -100,7 +110,7 @@ def format_exception_errors(err):
     return {identifier: [msg]}
 
 
-def write_collect_record(collect_record, request, dry_run=False):
+def _write_collect_record_once(collect_record, request, dry_run=False):
     status = None
     result = None
     context = {"request": request}
@@ -115,8 +125,13 @@ def write_collect_record(collect_record, request, dry_run=False):
             status = VALIDATION_ERROR_STATUS
         except Exception as err:
             logger.exception("write_collect_record: {}".format(getattr(collect_record, "id")))
-            result = format_exception_errors(err)
             status = ERROR_STATUS
+            # A deadlock here can't be resolved by swallowing it into a normal
+            # ERROR_STATUS result - the transaction needs to be retried from
+            # scratch. Let it propagate to write_collect_record's retry loop.
+            if _is_deadlock_error(err):
+                raise
+            result = format_exception_errors(err)
         finally:
             if dry_run is True or status != SUCCESS_STATUS:
                 transaction.savepoint_rollback(sid)
@@ -136,6 +151,44 @@ def write_collect_record(collect_record, request, dry_run=False):
 
                 add_project_to_queue(collect_record.project_id)
         return status, result
+
+
+def write_collect_record(collect_record, request, dry_run=False):
+    """
+    Concurrent submissions to the same project can deadlock while writing
+    revision records (see api/models/revisions.py) - either while writer.write()
+    saves observations/sample units, or while the collect record itself is
+    deleted on submit. Postgres aborts the transaction when it detects a
+    deadlock, so it can't be recovered from inside that transaction; it has
+    to be retried from scratch with a fresh one, which is what this wraps
+    _write_collect_record_once() in a loop to do.
+    """
+    for attempt in range(DEADLOCK_MAX_RETRIES + 1):
+        try:
+            return _write_collect_record_once(collect_record, request, dry_run=dry_run)
+        except OperationalError as err:
+            if not _is_deadlock_error(err):
+                raise
+
+            if attempt == DEADLOCK_MAX_RETRIES:
+                logger.exception(
+                    "write_collect_record: deadlock retries exhausted for {}".format(
+                        getattr(collect_record, "id")
+                    )
+                )
+                return ERROR_STATUS, format_exception_errors(err)
+
+            logger.warning(
+                "write_collect_record: deadlock detected for %s, retrying (attempt %s/%s)",
+                getattr(collect_record, "id"),
+                attempt + 1,
+                DEADLOCK_MAX_RETRIES,
+            )
+            time.sleep(DEADLOCK_RETRY_DELAY * (attempt + 1))
+            refetched = CollectRecord.objects.get_or_none(id=collect_record.id)
+            if refetched is None:
+                return ERROR_STATUS, gettext_lazy("Not found")
+            collect_record = refetched
 
 
 def validate(validator_cls, model_cls, qry_params=None):

--- a/src/api/tests/test_submission_deadlock_retry.py
+++ b/src/api/tests/test_submission_deadlock_retry.py
@@ -1,0 +1,127 @@
+from unittest.mock import MagicMock, patch
+
+from django.db.utils import OperationalError
+from django.urls import reverse
+
+from api.models import CollectRecord
+from api.submission.utils import (
+    DEADLOCK_MAX_RETRIES,
+    ERROR_STATUS,
+    SUCCESS_STATUS,
+    write_collect_record,
+)
+from api.submission.validations import OK
+from api.submission.validations.validators import DrySubmitValidator
+from api.utils import Testing
+
+DEADLOCK_ERROR = OperationalError(
+    "deadlock detected\nDETAIL: Process 1 waits for ShareLock on transaction 2; "
+    'blocked by process 2.\nCONTEXT: while inserting index tuple in relation "revision"'
+)
+
+
+def _writer_mock(write_side_effect):
+    writer = MagicMock()
+    writer.write.side_effect = write_side_effect
+    return writer
+
+
+def test_writer_write_deadlock_is_retried_and_succeeds(valid_collect_record, profile1_request):
+    """
+    A deadlock raised while writer.write() saves observations/sample units
+    (not just the collect_record.delete() step) must also be retried - this
+    is the path write_collect_record's own `except Exception` used to
+    silently swallow into an ERROR_STATUS result with no retry.
+    """
+    collect_record_id = valid_collect_record.id
+    writer = _writer_mock([DEADLOCK_ERROR, None])
+
+    with Testing(), patch("api.submission.utils.get_writer", return_value=writer), patch(
+        "api.submission.utils.time.sleep"
+    ):
+        status, result = write_collect_record(valid_collect_record, profile1_request)
+
+    assert writer.write.call_count == 2
+    assert status == SUCCESS_STATUS
+    assert result is None
+    assert CollectRecord.objects.filter(id=collect_record_id).exists() is False
+
+
+def test_writer_write_deadlock_exhausts_retries_and_reports_error(
+    valid_collect_record, profile1_request
+):
+    collect_record_id = valid_collect_record.id
+    writer = _writer_mock(DEADLOCK_ERROR)
+
+    with Testing(), patch("api.submission.utils.get_writer", return_value=writer), patch(
+        "api.submission.utils.time.sleep"
+    ):
+        status, result = write_collect_record(valid_collect_record, profile1_request)
+
+    assert writer.write.call_count == DEADLOCK_MAX_RETRIES + 1
+    assert status == ERROR_STATUS
+    # transaction was rolled back each time - record is left intact
+    assert CollectRecord.objects.filter(id=collect_record_id).exists() is True
+
+
+def test_dry_submit_validator_retries_after_writer_write_deadlock(
+    valid_collect_record, profile1_request
+):
+    """
+    DrySubmitValidator calls write_collect_record(..., dry_run=True) directly,
+    with no retry/exception handling of its own - it relies entirely on
+    write_collect_record to absorb transient deadlocks.
+    """
+    writer = _writer_mock([DEADLOCK_ERROR, None])
+
+    with Testing(), patch("api.submission.utils.get_writer", return_value=writer), patch(
+        "api.submission.utils.time.sleep"
+    ):
+        validator = DrySubmitValidator()
+        result = validator(valid_collect_record, request=profile1_request)
+
+    assert writer.write.call_count == 2
+    assert result.status == OK
+    # dry run always rolls back, regardless of outcome
+    assert CollectRecord.objects.filter(id=valid_collect_record.id).exists() is True
+
+
+def test_non_deadlock_operational_error_is_not_retried(valid_collect_record, profile1_request):
+    other_error = OperationalError("connection reset by peer")
+    writer = _writer_mock(other_error)
+
+    with Testing(), patch("api.submission.utils.get_writer", return_value=writer), patch(
+        "api.submission.utils.time.sleep"
+    ) as mock_sleep:
+        status, result = write_collect_record(valid_collect_record, profile1_request)
+
+    assert writer.write.call_count == 1
+    assert mock_sleep.call_count == 0
+    assert status == ERROR_STATUS
+
+
+def test_submit_endpoint_reports_error_instead_of_500_under_persistent_deadlock(
+    db_setup, api_client1, project1, collect_record4_with_v2_validation
+):
+    """
+    Reproduces the shape of the production incident: POST .../collectrecords/submit/
+    with a collect record whose write always deadlocks. Before this fix, the
+    deadlock from collect_record.delete() (or, previously unretried, from
+    writer.write()) propagated uncaught all the way to the view as a 500.
+    """
+    collect_record_id = str(collect_record4_with_v2_validation.pk)
+    writer = _writer_mock(DEADLOCK_ERROR)
+    url = reverse("collectrecords-submit", kwargs={"project_pk": str(project1.pk)})
+
+    with patch("api.submission.utils.get_writer", return_value=writer), patch(
+        "api.submission.utils.time.sleep"
+    ):
+        response = api_client1.post(
+            url, data={"version": "2", "ids": [collect_record_id]}, format="json"
+        )
+
+    response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data[collect_record_id]["status"] == "error"
+    assert CollectRecord.objects.filter(id=collect_record_id).exists() is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission reliability by automatically retrying collect-record saves when temporary database deadlocks occur.
  * Added clearer error handling when retries are exhausted or the requested record is no longer available.
  * Prevented deadlock-related failures from appearing as unexpected server errors.
  * Preserved existing behavior for other operational errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->