### PR TITLE
fix: [M2070] Skip S3 directory markers on download

### DIFF
--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -4,13 +4,13 @@ import pathlib
 import struct
 import zlib
 from fractions import Fraction
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image as PILImage
 
 from api.models import BenthicTransect, QuadratCollection, QuadratTransect, SampleUnit
-from api.utils import get_subclasses
+from api.utils import get_subclasses, s3
 from api.utils.classification import (
     _normalize_exif_value,
     extract_datetime_stamp,
@@ -226,3 +226,62 @@ def test_normalize_exif_value(value, expected):
     assert result == expected
     if expected is not None:
         assert type(result) is type(expected)  # 42 must stay int, not become 42.0
+
+
+def _fake_s3_client(keys):
+    """boto3 client stub that pages through keys and, like the real client, creates the
+    destination file on download."""
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": [{"Key": key} for key in keys]}]
+    client.get_paginator.return_value = paginator
+
+    def _download_file(bucket, key, local_path):
+        with open(local_path, "wb"):
+            pass
+
+    client.download_file.side_effect = _download_file
+    return client
+
+
+def _downloaded_keys(client):
+    return [call.args[1] for call in client.download_file.call_args_list]
+
+
+def test_list_objects_download_skips_directory_markers(tmp_path):
+    # A "folder" created via the S3 console has a zero-byte marker object keyed exactly like
+    # the prefix, and it always sorts first. Downloading it writes a *file* at the download
+    # root, after which every real key dies in os.makedirs (exist_ok only tolerates an
+    # existing directory) with "[Errno 17] File exists".
+    keys = [
+        "classifier/v1/",
+        "classifier/v1/classifier.pkl",
+        "classifier/v1/efficientnet_weights.pt",
+    ]
+    client = _fake_s3_client(keys)
+    download_to = tmp_path / "classifier" / "v1"
+
+    with patch("api.utils.s3.get_client", return_value=client):
+        objects = s3.list_objects(
+            "mermaid-config", prefix="classifier/v1/", download_to=str(download_to)
+        )
+
+    assert [obj["Key"] for obj in objects] == keys  # markers are still returned to callers
+    assert download_to.is_dir()  # marker became the directory, not a file
+    assert (download_to / "classifier.pkl").is_file()
+    assert (download_to / "efficientnet_weights.pt").is_file()
+    assert _downloaded_keys(client) == keys[1:]  # marker itself never downloaded
+
+
+def test_list_objects_download_skips_keys_outside_download_root(tmp_path):
+    # The traversal guard must keep working; the marker skip is layered on top of it.
+    keys = ["backups/dev/../../../etc/passwd", "backups/dev/good.dump"]
+    client = _fake_s3_client(keys)
+    download_to = tmp_path / "backups" / "dev"
+
+    with patch("api.utils.s3.get_client", return_value=client):
+        s3.list_objects("mermaid-backup", prefix="backups/dev/", download_to=str(download_to))
+
+    assert _downloaded_keys(client) == ["backups/dev/good.dump"]
+    assert (download_to / "good.dump").is_file()
+    assert not (tmp_path / "etc").exists()

--- a/src/api/utils/s3.py
+++ b/src/api/utils/s3.py
@@ -115,6 +115,11 @@ def list_objects(
                 )
                 if os.path.commonpath([download_root, local_path]) != download_root:
                     continue
+                if s3_key.endswith("/"):
+                    # Zero-byte S3 directory marker: create the directory rather than
+                    # downloading the marker over the top of it as a file.
+                    os.makedirs(local_path, exist_ok=True)
+                    continue
                 os.makedirs(os.path.dirname(local_path), exist_ok=True)
                 if os.path.isdir(local_path):
                     continue


### PR DESCRIPTION
Fixes photo quadrat AI classification, failing on dev with `[Errno 17] File exists: '/tmp/classifier/v1'`.

## Why

`s3://mermaid-config/classifier/v1/` has a zero-byte directory-marker object keyed exactly like the prefix, and S3 lists it first. `list_objects` downloaded it as a *file* at the download root, so every following key failed in `os.makedirs(..., exist_ok=True)`, which only tolerates an existing directory. `classifier.pkl` and `efficientnet_weights.pt` never downloaded and the classification job died.

Regression from `a3992d14` in #751: `os.path.abspath()` was added for the new traversal guard, and it normalises away the trailing `/.` that used to make the marker match the `isdir()` skip by accident.

## How

Keys ending in `/` now create the directory instead of being downloaded. Sits after the traversal guard, which is unchanged. `classification.py:357` is the only caller passing `download_to=`.

## Testing

Two tests in `api/tests/test_utils.py`: one for the regression, one pinning the traversal guard. Confirmed the first fails without the fix, with the same error seen in production.

## Notes
Deploying replaces the ECS worker tasks, which clears the bad file from `/tmp`. No manual cleanup needed. Prod is unaffected, but this needs to be merged before the next release.

dbrestore broke through a different mechanism in the same PR and is fixed separately in #756. No potential conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * S3 directory markers are now handled correctly by creating local directories without downloading them as files.
  * Valid S3 objects continue to download as expected.
  * Path-traversal keys remain excluded for improved file safety.

* **Tests**
  * Added coverage for directory markers, object downloads, and path-traversal protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->