### PR TITLE
[M2082] Add cache method when querying data for validators

### DIFF
--- a/src/api/submission/validations/validators/base.py
+++ b/src/api/submission/validations/validators/base.py
@@ -95,6 +95,7 @@ def validate_list(func):
 
 class BaseValidator:
     result = None
+    RUN_CACHE_KEY = "_validation_run_cache"
 
     def __init__(self, **kwargs):
         self.context = kwargs or {}
@@ -115,6 +116,16 @@ class BaseValidator:
     @validator_result
     def skip(self, context=None):
         return OK, None, context
+
+    def get_run_cache(self, record, namespace):
+        """Namespaced scratch space shared by every validator in one validation run.
+
+        ValidationRunner hands the same collect record dict to each validator in a
+        run, so the dict doubles as a cache that goes away when the run ends. Only
+        available to validators that receive the serialized record, not the ones
+        declaring requires_instance.
+        """
+        return record.setdefault(self.RUN_CACHE_KEY, {}).setdefault(namespace, {})
 
     def get_value(self, record, key):
         return get_value(record, key, delimiter=".")

--- a/src/api/submission/validations/validators/classification_benthic_photo_quadrat.py
+++ b/src/api/submission/validations/validators/classification_benthic_photo_quadrat.py
@@ -113,6 +113,15 @@ class DuplicateImageValidator(BaseValidator):
 
 class BaseAnnotationValidator(BaseValidator):
     def get_rows(self, collect_record, **kwargs):
+        # The confirmed, unclassified and region validators all need the same rows,
+        # so build them once per validation run.
+        cache = self.get_run_cache(collect_record, "annotation_rows")
+        if "rows" not in cache:
+            cache["rows"] = self._build_rows(collect_record)
+
+        return cache["rows"]
+
+    def _build_rows(self, collect_record):
         cr_id = collect_record.get("id")
 
         num_points_per_quadrat = (collect_record["data"].get("quadrat_transect") or {}).get(
@@ -122,7 +131,9 @@ class BaseAnnotationValidator(BaseValidator):
             num_points_per_quadrat = Classifier.latest().num_points
 
         annos = (
-            Annotation.objects.select_related("point", "point__image")
+            Annotation.objects.select_related(
+                "point", "point__image", "benthic_attribute", "growth_form"
+            )
             .filter(point__image__collect_record_id=cr_id)
             .order_by(
                 "point__image__created_on",

--- a/src/api/submission/validations/validators/sample_unit_consistency.py
+++ b/src/api/submission/validations/validators/sample_unit_consistency.py
@@ -49,13 +49,36 @@ class SampleEventConsistencyValidator(BaseValidator):
         if sample_date is None:
             return None  # Let other validators handle invalid dates
 
-        sample_event = SampleEvent.objects.filter(
-            site_id=site_id,
-            management_id=management_id,
-            sample_date=sample_date,
-        ).first()
+        cache = self.get_run_cache(collect_record, "sample_events")
+        key = (str(site_id), str(management_id), sample_date)
+        if key not in cache:
+            cache[key] = SampleEvent.objects.filter(
+                site_id=site_id,
+                management_id=management_id,
+                sample_date=sample_date,
+            ).first()
 
-        return sample_event
+        return cache[key]
+
+    def _get_sibling_sample_units(
+        self, collect_record, sample_event, model, sample_event_path, select_related=()
+    ):
+        """Sample units of one protocol already recorded against a sample event.
+
+        A protocol can stack several of these checks against the same rows: BPQT
+        compares num_quadrats, num_points_per_quadrat and len_surveyed, all of which
+        live on the same quadrat_transect. Cache the rows for the validation run so
+        they are fetched once rather than once per validator.
+        """
+        cache = self.get_run_cache(collect_record, "sibling_sample_units")
+        key = (model, sample_event_path, str(sample_event.pk), select_related)
+        if key not in cache:
+            queryset = model.objects.filter(**{sample_event_path: sample_event})
+            if select_related:
+                queryset = queryset.select_related(*select_related)
+            cache[key] = list(queryset)
+
+        return cache[key]
 
 
 class DifferentNumQuadratsValidator(SampleEventConsistencyValidator):
@@ -77,11 +100,13 @@ class DifferentNumQuadratsValidator(SampleEventConsistencyValidator):
         if not sample_event or not num_quadrats:
             return OK
 
-        queryset = BenthicPhotoQuadratTransect.objects.filter(
-            quadrat_transect__sample_event=sample_event
-        ).select_related("quadrat_transect")
-
-        for pqt_su in queryset:
+        for pqt_su in self._get_sibling_sample_units(
+            collect_record,
+            sample_event,
+            BenthicPhotoQuadratTransect,
+            "quadrat_transect__sample_event",
+            ("quadrat_transect",),
+        ):
             other_num_quadrats = pqt_su.quadrat_transect.num_quadrats
             if other_num_quadrats != num_quadrats:
                 return (
@@ -124,11 +149,13 @@ class DifferentNumPointsPerQuadratValidator(SampleEventConsistencyValidator):
         if not sample_event or not num_points_per_quadrat:
             return OK
 
-        queryset = BenthicPhotoQuadratTransect.objects.filter(
-            quadrat_transect__sample_event=sample_event
-        ).select_related("quadrat_transect")
-
-        for pqt_su in queryset:
+        for pqt_su in self._get_sibling_sample_units(
+            collect_record,
+            sample_event,
+            BenthicPhotoQuadratTransect,
+            "quadrat_transect__sample_event",
+            ("quadrat_transect",),
+        ):
             other_num_points_per_quadrat = pqt_su.quadrat_transect.num_points_per_quadrat
             if other_num_points_per_quadrat != num_points_per_quadrat:
                 return (
@@ -162,10 +189,9 @@ class DifferentTransectWidthValidator(SampleEventConsistencyValidator):
         if not sample_event or not width_id:
             return OK
 
-        queryset = FishBeltTransect.objects.filter(sample_event=sample_event).select_related(
-            "width"
-        )
-        for fb_su in queryset:
+        for fb_su in self._get_sibling_sample_units(
+            collect_record, sample_event, FishBeltTransect, "sample_event"
+        ):
             other_width_id = valid_id(fb_su.width_id)
             if other_width_id:
                 other_width_id = str(other_width_id)
@@ -204,10 +230,9 @@ class DifferentInvertTransectWidthValidator(SampleEventConsistencyValidator):
             return OK
 
         width_id = str(width_id)
-        queryset = InvertBeltTransect.objects.filter(sample_event=sample_event).select_related(
-            "width"
-        )
-        for su in queryset:
+        for su in self._get_sibling_sample_units(
+            collect_record, sample_event, InvertBeltTransect, "sample_event"
+        ):
             other_width_id = valid_id(su.width_id)
             if other_width_id:
                 if str(other_width_id) != width_id:
@@ -269,12 +294,11 @@ class DifferentTransectLengthValidator(SampleEventConsistencyValidator):
             return OK
 
         model, sample_event_path = self.PROTOCOL_CONFIG[protocol]
-        queryset = model.objects.filter(**{sample_event_path: sample_event}).select_related(
-            sample_event_path
-        )
+        su_str = sample_event_path.split("__")[0]  # transect or quadrat_transect
 
-        for method in queryset:
-            su_str = sample_event_path.split("__")[0]  # transect or quadrat_transect
+        for method in self._get_sibling_sample_units(
+            collect_record, sample_event, model, sample_event_path, (su_str,)
+        ):
             su = getattr(method, su_str)
             other_len_surveyed = su.len_surveyed
 
@@ -311,11 +335,13 @@ class DifferentQuadratSizeValidator(SampleEventConsistencyValidator):
         if not sample_event or not quadrat_size:
             return OK
 
-        queryset = BleachingQuadratCollection.objects.filter(
-            quadrat__sample_event=sample_event
-        ).select_related("quadrat")
-
-        for bqc_su in queryset:
+        for bqc_su in self._get_sibling_sample_units(
+            collect_record,
+            sample_event,
+            BleachingQuadratCollection,
+            "quadrat__sample_event",
+            ("quadrat",),
+        ):
             other_quadrat_size = bqc_su.quadrat.quadrat_size
             if other_quadrat_size != quadrat_size:
                 return (

--- a/src/api/tests/validators/test_classification_benthic_photo_quadrat.py
+++ b/src/api/tests/validators/test_classification_benthic_photo_quadrat.py
@@ -10,7 +10,11 @@ from api.models import (
 )
 from api.resources.collect_record import CollectRecordSerializer
 from api.submission.validations import OK, WARN
-from api.submission.validations.validators import ImageCountValidator
+from api.submission.validations.validators import (
+    ImageCountValidator,
+    ListAnnotationConfirmedValidator,
+    ListAnnotationUnclassifiedValidator,
+)
 
 
 @pytest.fixture
@@ -134,3 +138,35 @@ def test_image_count_validator(image_collect_record_serialized, annotations, ima
     result = validator(image_collect_record_serialized)
     assert result.status == OK
     assert result.code is None
+
+
+def test_get_rows(image_collect_record_serialized, annotations):
+    validator = ListAnnotationConfirmedValidator()
+    rows = validator.get_rows(image_collect_record_serialized)
+
+    # 2 confirmed annotations on image1, 1 confirmed and 1 unconfirmed on image2.
+    assert len(rows) == 4
+    assert [r for r in rows if r["is_unclassified"]] == []
+    assert sum(r["confirmed"] for r in rows) == 3
+    assert sum(r["unconfirmed"] for r in rows) == 1
+
+
+def test_get_rows_cached_per_validation_run(
+    image_collect_record_serialized, annotations, django_assert_num_queries
+):
+    rows = ListAnnotationConfirmedValidator().get_rows(image_collect_record_serialized)
+
+    # Another validator in the same run reuses the rows built by the first.
+    with django_assert_num_queries(0):
+        assert (
+            ListAnnotationUnclassifiedValidator().get_rows(image_collect_record_serialized) is rows
+        )
+
+
+def test_get_rows_not_cached_across_validation_runs(image_collect_record, annotations):
+    validator = ListAnnotationConfirmedValidator()
+    rows = validator.get_rows(CollectRecordSerializer(instance=image_collect_record).data)
+    refreshed_rows = validator.get_rows(CollectRecordSerializer(instance=image_collect_record).data)
+
+    assert refreshed_rows is not rows
+    assert refreshed_rows == rows

--- a/src/api/tests/validators/test_sample_unit_consistency.py
+++ b/src/api/tests/validators/test_sample_unit_consistency.py
@@ -286,3 +286,37 @@ def test_different_quadrat_size_different_value(
     assert result.code == DifferentQuadratSizeValidator.DIFFERENT_QUADRAT_SIZE
     assert result.context["quadrat_size"] == 2.0
     assert result.context["other_quadrat_size"] == 1.0
+
+
+# ==================== per-validation-run caching tests ====================
+
+
+def test_bpqt_consistency_validators_share_one_sibling_fetch(
+    benthic_photo_quadrat_transect1,
+    valid_benthic_pq_transect_collect_record,
+    django_assert_num_queries,
+):
+    """BPQT stacks three of these checks, all against the same quadrat_transect row."""
+    quadrat_transect = valid_benthic_pq_transect_collect_record.data["quadrat_transect"]
+    quadrat_transect["num_quadrats"] = 2
+    quadrat_transect["num_points_per_quadrat"] = 100
+    quadrat_transect["len_surveyed"] = 50
+    valid_benthic_pq_transect_collect_record.save()
+
+    validators = [
+        _get_num_quadrats_validator(),
+        _get_num_points_per_quadrat_validator(),
+        DifferentTransectLengthValidator(
+            protocol_path="data.protocol",
+            site_path="data.sample_event.site",
+            management_path="data.sample_event.management",
+            sample_date_path="data.sample_event.sample_date",
+            len_surveyed_path="data.quadrat_transect.len_surveyed",
+        ),
+    ]
+    record = CollectRecordSerializer(instance=valid_benthic_pq_transect_collect_record).data
+
+    # One sample event lookup and one sibling sample unit fetch, shared by all three.
+    with django_assert_num_queries(2):
+        for validator in validators:
+            assert validator(record).status == OK


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced repeated database queries during validation by reusing annotation and sample-unit data within each validation run.
* **Tests**
  * Added coverage for validation caching, cache isolation, query efficiency, and annotation row reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->