### PR TITLE
[M2088] change mailchimp error to warning

### DIFF
--- a/src/api/auth_backends.py
+++ b/src/api/auth_backends.py
@@ -128,6 +128,8 @@ class JWTAuthentication(BaseAuthentication):
                 ):
                     from mailchimp3 import MailChimp
                     from mailchimp3.helpers import get_subscriber_hash
+                    from mailchimp3.mailchimpclient import MailChimpError
+                    from requests.exceptions import RequestException
 
                     # https://developer.mailchimp.com/documentation/mailchimp/guides/manage-subscribers-with-the
                     # -mailchimp-api/
@@ -149,10 +151,27 @@ class JWTAuthentication(BaseAuthentication):
                                 "merge_fields": merge_fields,
                             },
                         )
+                    except MailChimpError as err:
+                        # Merge-field validation failures (e.g. missing LNAME) are expected
+                        # for some signups and shouldn't page/pollute Sentry as errors.
+                        # Credential, rate-limit, and other API errors still log at error level.
+                        error_data = err.args[0] if err.args else {}
+                        status_code = getattr(error_data.get("response"), "status_code", None)
+                        is_validation_error = status_code == 400 and bool(error_data.get("errors"))
+                        log_fn = logger.warning if is_validation_error else logger.error
+                        log_fn(
+                            "Unable to create mailchimp member {} {} <{}>: {}".format(
+                                profile.first_name, profile.last_name, profile.email, str(err)
+                            )
+                        )
+                    except RequestException as err:
+                        logger.error(
+                            "Unable to create mailchimp member {} {} <{}>: {}".format(
+                                profile.first_name, profile.last_name, profile.email, str(err)
+                            )
+                        )
                     except Exception as err:  # Don't ever fail because subscription didn't work
-                        # Mailchimp merge-field validation failures (e.g. missing LNAME) are
-                        # expected for some signups and shouldn't page/pollute Sentry as errors.
-                        logger.warning(
+                        logger.error(
                             "Unable to create mailchimp member {} {} <{}>: {}".format(
                                 profile.first_name, profile.last_name, profile.email, str(err)
                             )

--- a/src/api/auth_backends.py
+++ b/src/api/auth_backends.py
@@ -150,7 +150,9 @@ class JWTAuthentication(BaseAuthentication):
                             },
                         )
                     except Exception as err:  # Don't ever fail because subscription didn't work
-                        logger.error(
+                        # Mailchimp merge-field validation failures (e.g. missing LNAME) are
+                        # expected for some signups and shouldn't page/pollute Sentry as errors.
+                        logger.warning(
                             "Unable to create mailchimp member {} {} <{}>: {}".format(
                                 profile.first_name, profile.last_name, profile.email, str(err)
                             )


### PR DESCRIPTION
Sentry was alerting on /v1/me/ errors caused by Mailchimp merge-field validation failures (e.g., users signing up without a last name), even though the failure is already caught and doesn't affect account creation. Changed the log level from error to warning in auth_backends.py so Sentry stops treating this expected, non-fatal case as an incident.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mailchimp signup error handling and logging.
  * Expected validation errors are reported as warnings, while unexpected Mailchimp failures, network errors, and other unexpected issues are logged as errors for better visibility and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->