### PR TITLE
increase container memory

### DIFF
--- a/iac/settings/prod.py
+++ b/iac/settings/prod.py
@@ -16,7 +16,9 @@ PROD_SETTINGS = ProjectSettings(
     api=DjangoSettings(
         # API
         container_cpu=1500,
-        container_memory=3000,
+        # 3000 MiB spiked to the cap daily (heavy obs/report serialization),
+        # OOM-killing gunicorn workers. Headroom above the ~3078 MiB peak.
+        container_memory=4096,
         container_count=1,
         # SQS
         sqs_cpu=2048,


### PR DESCRIPTION
https://wildlife-conservation-socie-rv.sentry.io/share/issue/dd4a9740cb89489cae1eb25f3a7199d9/

Increase prod API container memory (3000 → 4096 MiB)

Problem

Sentry's top prod error was "Worker (pid:…) was sent SIGKILL! Perhaps out of memory?" — 1,267 events over 14 days (release v2.28.0). Gunicorn workers were being killed and respawned repeatedly.

Root cause

The prod API container is capped at container_memory=3000 MiB. CloudWatch MemoryUtilized (ECS/ContainerInsights) shows:

- Daily min ~1,100 MiB (healthy floor after worker recycle)
- Daily avg ~1,900 MiB
- Daily max spiking to 3,000–3,078 MiB — hitting the container cap almost every day

When a request pushes the container to its cgroup limit, the OOM killer terminates a gunicorn worker (not PID 1, the master), so the master just respawns it and the ECS task never restarts — which is why there were 1,267 log events but zero task-level OutOfMemory stops. Gunicorn's "Perhaps out of memory?" guess is accurate here; the memory is genuinely at the limit. It is not a leak — the floor returns to ~1,100 MiB after --max-requests recycles workers.

The spikes come from memory-heavy requests: large paginated observation pulls (the summary obs endpoints serialize wide rows — 60+ columns plus JSON fields — and clients legitimately request ?limit=5000), compounded by concurrency (--workers 2 --threads 4 = up to 8 in-flight requests sharing one 3,000 MiB container).

Fix

Raise container_memory for the prod API service from 3000 to 4096 MiB, giving headroom above the observed ~3,078 MiB peak. container_cpu unchanged (1500). Fits the current t3a.large instances (7,845 MiB registered).

Why not cap max_page_size?

Lowering max_page_size (5000) was considered but rejected: prod access logs show limit=5000 is used 37,579 times in 3 days, almost entirely by the frontend observation endpoints (obstransectbenthicpqts, obstransectbeltfishes, etc.). Capping it would break a real client pattern and force 5× more requests (worsening the deep-offset query cost). Left at 5000.

Follow-ups (not in this PR)

- Deep-offset pagination / leaner serialization on the obs endpoints — the structural fix that removes the memory spike at its source.
- Point bulk-export consumers at the streaming CSV report (reports/csv_report.py) rather than large JSON pages.
- If 4096 still touches the cap after deploy, next step is 6144 MiB or reducing gunicorn threads.

Verification

cdk diff prod-mermaid-api-django shows only the ApiTaskDefinition Memory: 3000 → 4096 change (plus the expected new image digest and a task reschedule). Watch MemoryUtilized peak and the SIGKILL event count after deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased production API container memory allocation to improve stability during heavy observation and report serialization.
  - Reduced the risk of worker processes being terminated when memory usage approaches the previous limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->