### PR TITLE
[M2087] Centralize `rules` definition in management serializers

### DIFF
--- a/src/api/resources/management.py
+++ b/src/api/resources/management.py
@@ -39,27 +39,45 @@ def get_rules(obj):
     return ",".join(rules)
 
 
-class ManagementExtendedSerializer(ExtendedSerializer):
+class ManagementRulesMixin:
+    """Shared `rules` field for the plain (/managements/), project-nested
+    (/projects/<id>/managements/), and extended (nested-in-sample-event)
+    Management serializers, so the three stay in sync instead of drifting
+    independently.
+
+    Injected via get_fields() rather than declared as a normal class-level
+    field: DRF's SerializerMetaclass only collects declared fields from
+    bases that have themselves already been processed by that metaclass,
+    and this is a plain mixin, so a class-level Field here would silently
+    never make it into `_declared_fields` (see the identical note on
+    _DuplicateCheckMixin in mixins.py).
+    """
+
+    def get_fields(self):
+        fields = super().get_fields()
+        fields["rules"] = serializers.SerializerMethodField(source="get_rules")
+        return fields
+
+    def get_rules(self, obj):
+        return get_rules(obj)
+
+
+class ManagementExtendedSerializer(ManagementRulesMixin, ExtendedSerializer):
     project = ModelNameReadOnlyField()
     compliance = ModelNameReadOnlyField()
     parties = serializers.ListField(source="parties.all", child=ModelNameReadOnlyField())
-    rules = serializers.SerializerMethodField(source="get_rules")
 
     class Meta:
         geo_field = "boundary"
         model = Management
         exclude = []
 
-    def get_rules(self, obj):
-        return get_rules(obj)
 
-
-class ManagementSerializer(BaseAPISerializer):
+class ManagementSerializer(ManagementRulesMixin, BaseAPISerializer):
     # No ManagementDuplicateCheckMixin here: this serializer's only write
     # path is create_project's bulk copy into a brand-new project, which
     # never has existing submitted data for the check's precondition to
     # match against -- it would just be dead weight on every call.
-    rules = serializers.SerializerMethodField(source="get_rules")
     project_name = serializers.SerializerMethodField()
     size = serializers.DecimalField(
         max_digits=12,
@@ -75,9 +93,6 @@ class ManagementSerializer(BaseAPISerializer):
         model = Management
         exclude = []
         additional_fields = ["rules", "project_name"]
-
-    def get_rules(self, obj):
-        return get_rules(obj)
 
     def get_project_name(self, obj):
         return obj.project.name

--- a/src/api/resources/pmanagement.py
+++ b/src/api/resources/pmanagement.py
@@ -10,7 +10,7 @@ from .base import (
     BaseProjectApiViewSet,
     NullableUUIDFilter,
 )
-from .management import get_rules
+from .management import ManagementRulesMixin, get_rules
 from .mixins import (
     CopyRecordsMixin,
     CreateOrUpdateSerializerMixin,
@@ -20,7 +20,10 @@ from .mixins import (
 
 
 class PManagementSerializer(
-    ManagementDuplicateCheckMixin, CreateOrUpdateSerializerMixin, BaseAPISerializer
+    ManagementRulesMixin,
+    ManagementDuplicateCheckMixin,
+    CreateOrUpdateSerializerMixin,
+    BaseAPISerializer,
 ):
     size = DecimalField(
         max_digits=12,

--- a/src/api/utils/__init__.py
+++ b/src/api/utils/__init__.py
@@ -9,14 +9,17 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.conf import settings
 from django.contrib.admin.utils import NestedObjects
-from django.core.exceptions import ObjectDoesNotExist, SuspiciousFileOperation
+from django.core.exceptions import (
+    ObjectDoesNotExist,
+    SuspiciousFileOperation,
+    ValidationError,
+)
 from django.db import IntegrityError, router
 from django.db.models.deletion import ProtectedError
 from django.db.models.fields.related import OneToOneRel
 from django.utils import timezone
 from django.utils.text import get_valid_filename
 from django.utils.translation import gettext_lazy as _
-from rest_framework.exceptions import ValidationError
 
 
 class Testing:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Management and PManagement API responses now consistently include management rules information.

* **Bug Fixes**
  * Improved validation error handling for maximum-year validation, providing more consistent error responses across the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->